### PR TITLE
DEP-60 feat : add Unauthorized, Forbidden exception handler

### DIFF
--- a/app/src/main/java/com/depromeet/threedays/front/controller/ApiControllerExceptionHandler.java
+++ b/app/src/main/java/com/depromeet/threedays/front/controller/ApiControllerExceptionHandler.java
@@ -1,16 +1,16 @@
 package com.depromeet.threedays.front.controller;
 
+import com.depromeet.threedays.front.exception.AuthorizedException;
 import com.depromeet.threedays.front.exception.PolicyViolationException;
 import com.depromeet.threedays.front.exception.ResourceNotFoundException;
 import com.depromeet.threedays.front.support.ApiResponse;
-import com.depromeet.threedays.front.support.ApiResponse.FailureBody;
 import com.depromeet.threedays.front.support.ApiResponseGenerator;
 import com.depromeet.threedays.front.support.FailureBodyResolver;
+import javax.naming.AuthenticationException;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -33,7 +33,7 @@ public class ApiControllerExceptionHandler {
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(IllegalArgumentException.class)
-    public final ApiResponse<Void> handleBadRequest(final IllegalArgumentException ex, final WebRequest request){
+    public final ApiResponse<Void> handleBadRequest(final IllegalArgumentException ex, final WebRequest request) {
         this.writeLog(ex, request);
         return ApiResponseGenerator.fail();
     }
@@ -80,11 +80,24 @@ public class ApiControllerExceptionHandler {
         return ApiResponseGenerator.fail();
     }
 
-    // TODO: FORBIDDEN, UNAUTHORIZED
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(AuthenticationException.class)
+    public final ApiResponse<ApiResponse.FailureBody> handleUnAuthorized(final AuthenticationException ex, final WebRequest request) {
+        this.writeLog(ex, request);
+        return ApiResponseGenerator.fail(FailureBodyResolver.resolveFrom(ex));
+    }
+
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @ExceptionHandler(AuthorizedException.class)
+    public final ApiResponse<ApiResponse.FailureBody> handleForbidden(final AuthorizedException ex, final WebRequest request) {
+        this.writeLog(ex, request);
+        return ApiResponseGenerator.fail(FailureBodyResolver.resolveFrom(ex));
+    }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Exception.class)
-    public ApiResponse<Void> handleInternalServerError(final Exception ex, final WebRequest request){
+    public ApiResponse<Void> handleInternalServerError(final Exception ex, final WebRequest request) {
+
         this.writeLog(ex, request);
         return ApiResponseGenerator.fail();
     }

--- a/app/src/main/java/com/depromeet/threedays/front/exception/AuthorizedException.java
+++ b/app/src/main/java/com/depromeet/threedays/front/exception/AuthorizedException.java
@@ -1,0 +1,14 @@
+package com.depromeet.threedays.front.exception;
+
+import javax.validation.constraints.NotEmpty;
+
+public class AuthorizedException extends RuntimeException{
+
+    public AuthorizedException(@NotEmpty final String message) {
+        super(message);
+    }
+
+    public AuthorizedException(@NotEmpty final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/app/src/main/java/com/depromeet/threedays/front/support/FailureBodyResolver.java
+++ b/app/src/main/java/com/depromeet/threedays/front/support/FailureBodyResolver.java
@@ -1,6 +1,8 @@
 package com.depromeet.threedays.front.support;
 
+import com.depromeet.threedays.front.exception.AuthorizedException;
 import com.depromeet.threedays.front.support.ApiResponse.FailureBody;
+import javax.naming.AuthenticationException;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Path;
 import lombok.experimental.UtilityClass;
@@ -19,7 +21,7 @@ public class FailureBodyResolver {
 				fieldName = node.getName();
 			}
 
-			return new ApiResponse.FailureBody(fieldName, v.getMessage())
+			return new ApiResponse.FailureBody(fieldName, v.getMessage());
 		}).findFirst().orElse(null);
 	}
 
@@ -36,6 +38,15 @@ public class FailureBodyResolver {
 			return new ApiResponse.FailureBody(error.getCode(), error.getDefaultMessage());
 		}
 		return null;
+	}
+
+	public static ApiResponse.FailureBody resolveFrom(final AuthenticationException ex) {
+		return new ApiResponse.FailureBody(ex.getMessage());
+	}
+
+
+	public static ApiResponse.FailureBody resolveFrom(final AuthorizedException ex) {
+		return new ApiResponse.FailureBody(ex.getMessage());
 	}
 
 }


### PR DESCRIPTION
💁‍♂️ PR 내용
----
UNAUTHORIZED와 FORBIDDEN에 대한 예외 핸들러 구현

🙏 작업
----
HttpStatus.UnAuthorized 의 의미가 인가보다는 인증에 가깝다고 생각해 AuthenticationException.class를 타겟으로 처리하도록 하였습니다.

HttpStatus.Forbidden은 인가에 가깝다고 생각하여, 커스텀한 AuthorizedException.class를 추가해 타겟으로 처리하도록 하였습니다.
