### PR TITLE
Dep-124 feat : habit achievement post api

### DIFF
--- a/app/src/main/java/com/depromeet/threedays/front/controller/habit/HabitController.java
+++ b/app/src/main/java/com/depromeet/threedays/front/controller/habit/HabitController.java
@@ -1,20 +1,19 @@
 package com.depromeet.threedays.front.controller.habit;
 
+import com.depromeet.threedays.front.controller.request.habit.SaveHabitAchievementRequest;
 import com.depromeet.threedays.front.controller.request.habit.SaveHabitRequest;
 import com.depromeet.threedays.front.domain.model.habit.Habit;
 import com.depromeet.threedays.front.domain.model.habit.HabitOverview;
+import com.depromeet.threedays.front.domain.usecase.habit.SaveHabitAchievementUseCase;
 import com.depromeet.threedays.front.domain.usecase.habit.SaveHabitUseCase;
 import com.depromeet.threedays.front.domain.usecase.habit.SearchHabitUseCase;
 import com.depromeet.threedays.front.support.ApiResponse;
 import com.depromeet.threedays.front.support.ApiResponseGenerator;
+
 import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,6 +24,8 @@ public class HabitController {
 
 	private final SearchHabitUseCase searchUseCase;
 
+	private final SaveHabitAchievementUseCase saveHabitAchievementUseCase;
+
 	@PostMapping
 	public ApiResponse<Habit> add(@RequestBody @Valid final SaveHabitRequest request) {
 		return ApiResponseGenerator.success(saveUseCase.execute(request));
@@ -33,5 +34,12 @@ public class HabitController {
 	@GetMapping
 	public ApiResponse<List<HabitOverview>> browse() {
 		return ApiResponseGenerator.success(searchUseCase.execute());
+	}
+
+	@PostMapping("/{habitId}/achievements")
+	public ApiResponse<Habit> addAchievement(
+			@PathVariable("habitId") Long habitId,
+			@RequestBody @Valid final SaveHabitAchievementRequest request) {
+		return ApiResponseGenerator.success(saveHabitAchievementUseCase.execute(habitId, request));
 	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/controller/request/habit/SaveHabitAchievementRequest.java
+++ b/app/src/main/java/com/depromeet/threedays/front/controller/request/habit/SaveHabitAchievementRequest.java
@@ -1,18 +1,16 @@
 package com.depromeet.threedays.front.controller.request.habit;
 
+import java.time.LocalDate;
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import javax.validation.constraints.NotNull;
-import java.time.LocalDate;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder(toBuilder = true)
 public class SaveHabitAchievementRequest {
-    @NotNull
-    private LocalDate achievementDate;
+	@NotNull private LocalDate achievementDate;
 }

--- a/app/src/main/java/com/depromeet/threedays/front/controller/request/habit/SaveHabitAchievementRequest.java
+++ b/app/src/main/java/com/depromeet/threedays/front/controller/request/habit/SaveHabitAchievementRequest.java
@@ -1,0 +1,18 @@
+package com.depromeet.threedays.front.controller.request.habit;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class SaveHabitAchievementRequest {
+    @NotNull
+    private LocalDate achievementDate;
+}

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/RewardHistoryConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/RewardHistoryConverter.java
@@ -1,0 +1,20 @@
+package com.depromeet.threedays.front.domain.converter;
+
+import com.depromeet.threedays.data.entity.habit.HabitEntity;
+import com.depromeet.threedays.data.entity.history.RewardHistoryEntity;
+import com.depromeet.threedays.front.domain.model.habit.HabitAchievement;
+import lombok.experimental.UtilityClass;
+
+import java.time.LocalDateTime;
+
+@UtilityClass
+public class RewardHistoryConverter {
+
+    public static RewardHistoryEntity to(HabitEntity habitEntity, HabitAchievement habitAchievement) {
+        return RewardHistoryEntity.builder()
+                                  .habitId(habitEntity.getId())
+                                  .memberId(habitEntity.getMemberId())
+                                  .createDate(LocalDateTime.now())
+                                  .build();
+    }
+}

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/habit/HabitAchievementConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/habit/HabitAchievementConverter.java
@@ -18,34 +18,42 @@ public class HabitAchievementConverter {
 				.build();
 	}
 
-	public static HabitAchievementEntity to(HabitEntity habitEntity, SaveHabitAchievementRequest request, int dayDifference) {
+	public static HabitAchievementEntity to(
+			HabitEntity habitEntity, SaveHabitAchievementRequest request, int dayDifference) {
 		return HabitAchievementEntity.builder()
-									 .habitId(habitEntity.getId())
-									 .memberId(habitEntity.getMemberId())
-									 .achievementDate(request.getAchievementDate())
-									 .nextAchievementDate(request.getAchievementDate()
-																 .plusDays(dayDifference))
-									 .sequence(1)
-									 .build();
+				.habitId(habitEntity.getId())
+				.memberId(habitEntity.getMemberId())
+				.achievementDate(request.getAchievementDate())
+				.nextAchievementDate(request.getAchievementDate().plusDays(dayDifference))
+				.sequence(1)
+				.build();
 	}
 
-	public static HabitAchievementEntity to(HabitEntity habitEntity, HabitAchievementEntity habitAchievementEntity, SaveHabitAchievementRequest request) {
+	public static HabitAchievementEntity to(
+			HabitEntity habitEntity,
+			HabitAchievementEntity habitAchievementEntity,
+			SaveHabitAchievementRequest request) {
 		return HabitAchievementEntity.builder()
-									 .habitId(habitEntity.getId())
-									 .memberId(habitEntity.getMemberId())
-									 .achievementDate(request.getAchievementDate())
-									 .nextAchievementDate(habitAchievementEntity.getNextAchievementDate())
-									 .sequence(habitAchievementEntity.getSequence() + 1)
-									 .build();
+				.habitId(habitEntity.getId())
+				.memberId(habitEntity.getMemberId())
+				.achievementDate(request.getAchievementDate())
+				.nextAchievementDate(habitAchievementEntity.getNextAchievementDate())
+				.sequence(habitAchievementEntity.getSequence() + 1)
+				.build();
 	}
 
-	public static HabitAchievementEntity to(HabitEntity habitEntity, HabitAchievementEntity habitAchievementEntity, SaveHabitAchievementRequest request, int dayDifference) {
+	public static HabitAchievementEntity to(
+			HabitEntity habitEntity,
+			HabitAchievementEntity habitAchievementEntity,
+			SaveHabitAchievementRequest request,
+			int dayDifference) {
 		return HabitAchievementEntity.builder()
-									 .habitId(habitEntity.getId())
-									 .memberId(habitEntity.getMemberId())
-									 .achievementDate(request.getAchievementDate())
-									 .nextAchievementDate(habitAchievementEntity.getNextAchievementDate().plusDays(dayDifference))
-									 .sequence(habitAchievementEntity.getSequence() + 1)
-									 .build();
+				.habitId(habitEntity.getId())
+				.memberId(habitEntity.getMemberId())
+				.achievementDate(request.getAchievementDate())
+				.nextAchievementDate(
+						habitAchievementEntity.getNextAchievementDate().plusDays(dayDifference))
+				.sequence(habitAchievementEntity.getSequence() + 1)
+				.build();
 	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/habit/HabitAchievementConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/habit/HabitAchievementConverter.java
@@ -28,4 +28,14 @@ public class HabitAchievementConverter {
 									 .sequence(1)
 									 .build();
 	}
+
+	public static HabitAchievementEntity to(HabitEntity habitEntity, HabitAchievementEntity habitAchievementEntity, SaveHabitAchievementRequest request) {
+		return HabitAchievementEntity.builder()
+									 .habitId(habitEntity.getId())
+									 .memberId(habitEntity.getMemberId())
+									 .achievementDate(request.getAchievementDate())
+									 .nextAchievementDate(habitAchievementEntity.getNextAchievementDate())
+									 .sequence(habitAchievementEntity.getSequence() + 1)
+									 .build();
+	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/habit/HabitAchievementConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/habit/HabitAchievementConverter.java
@@ -1,6 +1,8 @@
 package com.depromeet.threedays.front.domain.converter.habit;
 
 import com.depromeet.threedays.data.entity.habit.HabitAchievementEntity;
+import com.depromeet.threedays.data.entity.habit.HabitEntity;
+import com.depromeet.threedays.front.controller.request.habit.SaveHabitAchievementRequest;
 import com.depromeet.threedays.front.domain.model.habit.HabitAchievement;
 import lombok.experimental.UtilityClass;
 
@@ -14,5 +16,16 @@ public class HabitAchievementConverter {
 				.habitAchievementId(entity.getId())
 				.sequence(entity.getSequence())
 				.build();
+	}
+
+	public static HabitAchievementEntity to(HabitEntity habitEntity, SaveHabitAchievementRequest request, int dayDifference) {
+		return HabitAchievementEntity.builder()
+									 .habitId(habitEntity.getId())
+									 .memberId(habitEntity.getMemberId())
+									 .achievementDate(request.getAchievementDate())
+									 .nextAchievementDate(request.getAchievementDate()
+																 .plusDays(dayDifference))
+									 .sequence(1)
+									 .build();
 	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/habit/HabitAchievementConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/habit/HabitAchievementConverter.java
@@ -38,4 +38,14 @@ public class HabitAchievementConverter {
 									 .sequence(habitAchievementEntity.getSequence() + 1)
 									 .build();
 	}
+
+	public static HabitAchievementEntity to(HabitEntity habitEntity, HabitAchievementEntity habitAchievementEntity, SaveHabitAchievementRequest request, int dayDifference) {
+		return HabitAchievementEntity.builder()
+									 .habitId(habitEntity.getId())
+									 .memberId(habitEntity.getMemberId())
+									 .achievementDate(request.getAchievementDate())
+									 .nextAchievementDate(habitAchievementEntity.getNextAchievementDate().plusDays(dayDifference))
+									 .sequence(habitAchievementEntity.getSequence() + 1)
+									 .build();
+	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/habit/HabitConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/habit/HabitConverter.java
@@ -29,6 +29,19 @@ public class HabitConverter {
 				.build();
 	}
 
+	public static Habit from(HabitEntity habitEntity, HabitAchievement habitAchievement, Long reward) {
+		return Habit.builder()
+					.habitId(habitEntity.getId())
+					.memberId(habitEntity.getMemberId())
+					.title(habitEntity.getTitle())
+					.imojiPath(habitEntity.getImojiPath())
+					.dayOfWeeks(habitEntity.getDayOfWeeks())
+					.reward(reward)
+					.createDate(habitEntity.getCreateDate())
+					.habitAchievement(habitAchievement)
+					.build();
+	}
+
 	public static HabitEntity to(Habit data) {
 		return HabitEntity.builder()
 				.memberId(data.getMemberId())

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/habit/HabitConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/habit/HabitConverter.java
@@ -29,17 +29,18 @@ public class HabitConverter {
 				.build();
 	}
 
-	public static Habit from(HabitEntity habitEntity, HabitAchievement habitAchievement, Long reward) {
+	public static Habit from(
+			HabitEntity habitEntity, HabitAchievement habitAchievement, Long reward) {
 		return Habit.builder()
-					.habitId(habitEntity.getId())
-					.memberId(habitEntity.getMemberId())
-					.title(habitEntity.getTitle())
-					.imojiPath(habitEntity.getImojiPath())
-					.dayOfWeeks(habitEntity.getDayOfWeeks())
-					.reward(reward)
-					.createDate(habitEntity.getCreateDate())
-					.habitAchievement(habitAchievement)
-					.build();
+				.habitId(habitEntity.getId())
+				.memberId(habitEntity.getMemberId())
+				.title(habitEntity.getTitle())
+				.imojiPath(habitEntity.getImojiPath())
+				.dayOfWeeks(habitEntity.getDayOfWeeks())
+				.reward(reward)
+				.createDate(habitEntity.getCreateDate())
+				.habitAchievement(habitAchievement)
+				.build();
 	}
 
 	public static HabitEntity to(Habit data) {
@@ -67,10 +68,7 @@ public class HabitConverter {
 	}
 
 	public static HabitOverview from(
-			HabitEntity entity,
-			HabitAchievement achievementData,
-			Long rewardCount,
-			Mate mate) {
+			HabitEntity entity, HabitAchievement achievementData, Long rewardCount, Mate mate) {
 
 		return HabitOverview.builder()
 				.habitId(entity.getId())

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/mate/MateConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/mate/MateConverter.java
@@ -8,9 +8,6 @@ import lombok.experimental.UtilityClass;
 public class MateConverter {
 
 	public static Mate from(MateEntity entity) {
-		return Mate.builder()
-				.level(entity.getLevel())
-				.characterType(entity.getCharacterType())
-				.build();
+		return Mate.builder().level(entity.getLevel()).characterType(entity.getCharacterType()).build();
 	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/notification/HabitNotificationConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/notification/HabitNotificationConverter.java
@@ -9,8 +9,7 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class HabitNotificationConverter {
 
-	public static HabitNotificationEntity to(
-			Notification data, Long habitId, DayOfWeek dayOfWeek) {
+	public static HabitNotificationEntity to(Notification data, Long habitId, DayOfWeek dayOfWeek) {
 		return HabitNotificationEntity.builder()
 				.habitId(habitId)
 				.memberId(AuditorHolder.get())

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitAchievementUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitAchievementUseCase.java
@@ -109,9 +109,9 @@ public class SaveHabitAchievementUseCase {
 		int dayDifference = 0;
 
 		for (DayOfWeek dayOfWeek : dayOfWeeks) {
-			int objectiveDayOfWeek = dayOfWeek.getValue();
-			if (achievementDayOfWeek < objectiveDayOfWeek) {
-				dayDifference = objectiveDayOfWeek - achievementDayOfWeek;
+			int habitDayOfWeek = dayOfWeek.getValue();
+			if (achievementDayOfWeek < habitDayOfWeek) {
+				dayDifference = habitDayOfWeek - achievementDayOfWeek;
 				break;
 			}
 			count++;

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitAchievementUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitAchievementUseCase.java
@@ -1,53 +1,79 @@
 package com.depromeet.threedays.front.domain.usecase.habit;
 
+import com.depromeet.threedays.data.entity.habit.HabitAchievementEntity;
 import com.depromeet.threedays.data.entity.habit.HabitEntity;
 import com.depromeet.threedays.data.enums.DayOfWeek;
 import com.depromeet.threedays.front.controller.request.habit.SaveHabitAchievementRequest;
+import com.depromeet.threedays.front.domain.converter.habit.HabitAchievementConverter;
+import com.depromeet.threedays.front.domain.converter.habit.HabitConverter;
 import com.depromeet.threedays.front.domain.model.habit.Habit;
+import com.depromeet.threedays.front.domain.model.habit.HabitAchievement;
+import com.depromeet.threedays.front.exception.ResourceNotFoundException;
 import com.depromeet.threedays.front.repository.habit.HabitAchievementRepository;
 import com.depromeet.threedays.front.repository.habit.HabitRepository;
+import java.time.LocalDate;
+import java.util.EnumSet;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.util.EnumSet;
 
 @Component
 @Transactional
 @RequiredArgsConstructor
 public class SaveHabitAchievementUseCase {
-    private final HabitRepository habitRepository;
-    private final HabitAchievementRepository habitAchievementRepository;
+	private final HabitRepository habitRepository;
+	private final HabitAchievementRepository habitAchievementRepository;
 
-    public Habit execute(Long habitId, final SaveHabitAchievementRequest request) {
-        return null;
-    }
+	public Habit execute(Long habitId, final SaveHabitAchievementRequest request) {
 
-    private int calculateDayDifference(HabitEntity habitEntity, LocalDate achievementDate) {
-        EnumSet<DayOfWeek> dayOfWeeks = habitEntity.getDayOfWeeks();
-        int achievementDayOfWeek = achievementDate.getDayOfWeek()
-                                                  .getValue();
+		LocalDate achievementDate = request.getAchievementDate();
+		HabitEntity habitEntity =
+				habitRepository.findById(habitId).orElseThrow(ResourceNotFoundException::new);
 
-        int count = 0;
-        int dayDifference = 0;
+		HabitAchievementEntity habitAchievementEntity;
+		try {
+			habitAchievementEntity =
+					habitAchievementRepository
+							.findFirstByHabitIdOrderByAchievementDateDesc(habitId)
+							.orElseThrow(ResourceNotFoundException::new);
+		} catch (ResourceNotFoundException e) {
+			int dayDifference = calculateDayDifference(habitEntity, achievementDate);
 
-        for (DayOfWeek dayOfWeek : dayOfWeeks) {
-            int objectiveDayOfWeek = dayOfWeek.getValue();
-            if (achievementDayOfWeek < objectiveDayOfWeek) {
-                dayDifference = objectiveDayOfWeek - achievementDayOfWeek;
-                break;
-            }
-            count++;
-        }
+			HabitAchievementEntity savedHabitAchievementEntity =
+					habitAchievementRepository.save(
+							HabitAchievementConverter.to(habitEntity, request, dayDifference));
 
-        if (count == dayOfWeeks.size()) {
-            for (DayOfWeek dayOfWeek : dayOfWeeks) {
-                int habitDayOfWeek = dayOfWeek.getValue();
-                dayDifference = (habitDayOfWeek + 7) - achievementDayOfWeek;
-                break;
-            }
-        }
-        return dayDifference;
-    }
+			HabitAchievement habitAchievement =
+					HabitAchievementConverter.from(savedHabitAchievementEntity);
+			return HabitConverter.from(habitEntity, habitAchievement, 3L);
+		}
+
+		return null;
+	}
+
+	private int calculateDayDifference(HabitEntity habitEntity, LocalDate achievementDate) {
+		EnumSet<DayOfWeek> dayOfWeeks = habitEntity.getDayOfWeeks();
+		int achievementDayOfWeek = achievementDate.getDayOfWeek().getValue();
+
+		int count = 0;
+		int dayDifference = 0;
+
+		for (DayOfWeek dayOfWeek : dayOfWeeks) {
+			int objectiveDayOfWeek = dayOfWeek.getValue();
+			if (achievementDayOfWeek < objectiveDayOfWeek) {
+				dayDifference = objectiveDayOfWeek - achievementDayOfWeek;
+				break;
+			}
+			count++;
+		}
+
+		if (count == dayOfWeeks.size()) {
+			for (DayOfWeek dayOfWeek : dayOfWeeks) {
+				int habitDayOfWeek = dayOfWeek.getValue();
+				dayDifference = (habitDayOfWeek + 7) - achievementDayOfWeek;
+				break;
+			}
+		}
+		return dayDifference;
+	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitAchievementUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitAchievementUseCase.java
@@ -72,6 +72,16 @@ public class SaveHabitAchievementUseCase {
 			return HabitConverter.from(habitEntity, habitAchievement, 3L);
 		}
 
+		if (achievementDate.isAfter(nextAchievementDate)) {
+			int dayDifference = calculateDayDifference(habitEntity, achievementDate);
+			HabitAchievementEntity savedHabitAchievementEntity =
+					habitAchievementRepository.save(
+							HabitAchievementConverter.to(habitEntity, request, dayDifference));
+
+			HabitAchievement habitAchievement =
+					HabitAchievementConverter.from(savedHabitAchievementEntity);
+			return HabitConverter.from(habitEntity, habitAchievement, 3L);
+		}
 		return null;
 	}
 

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitAchievementUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitAchievementUseCase.java
@@ -1,0 +1,53 @@
+package com.depromeet.threedays.front.domain.usecase.habit;
+
+import com.depromeet.threedays.data.entity.habit.HabitEntity;
+import com.depromeet.threedays.data.enums.DayOfWeek;
+import com.depromeet.threedays.front.controller.request.habit.SaveHabitAchievementRequest;
+import com.depromeet.threedays.front.domain.model.habit.Habit;
+import com.depromeet.threedays.front.repository.habit.HabitAchievementRepository;
+import com.depromeet.threedays.front.repository.habit.HabitRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.EnumSet;
+
+@Component
+@Transactional
+@RequiredArgsConstructor
+public class SaveHabitAchievementUseCase {
+    private final HabitRepository habitRepository;
+    private final HabitAchievementRepository habitAchievementRepository;
+
+    public Habit execute(Long habitId, final SaveHabitAchievementRequest request) {
+        return null;
+    }
+
+    private int calculateDayDifference(HabitEntity habitEntity, LocalDate achievementDate) {
+        EnumSet<DayOfWeek> dayOfWeeks = habitEntity.getDayOfWeeks();
+        int achievementDayOfWeek = achievementDate.getDayOfWeek()
+                                                  .getValue();
+
+        int count = 0;
+        int dayDifference = 0;
+
+        for (DayOfWeek dayOfWeek : dayOfWeeks) {
+            int objectiveDayOfWeek = dayOfWeek.getValue();
+            if (achievementDayOfWeek < objectiveDayOfWeek) {
+                dayDifference = objectiveDayOfWeek - achievementDayOfWeek;
+                break;
+            }
+            count++;
+        }
+
+        if (count == dayOfWeeks.size()) {
+            for (DayOfWeek dayOfWeek : dayOfWeeks) {
+                int habitDayOfWeek = dayOfWeek.getValue();
+                dayDifference = (habitDayOfWeek + 7) - achievementDayOfWeek;
+                break;
+            }
+        }
+        return dayDifference;
+    }
+}

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitAchievementUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitAchievementUseCase.java
@@ -48,6 +48,18 @@ public class SaveHabitAchievementUseCase {
 			return HabitConverter.from(habitEntity, habitAchievement, 3L);
 		}
 
+		LocalDate nextAchievementDate = habitAchievementEntity.getNextAchievementDate();
+
+		if (achievementDate.isBefore(nextAchievementDate)) {
+			HabitAchievementEntity savedHabitAchievementEntity =
+					habitAchievementRepository.save(
+							HabitAchievementConverter.to(habitEntity, habitAchievementEntity, request));
+
+			HabitAchievement habitAchievement =
+					HabitAchievementConverter.from(savedHabitAchievementEntity);
+			return HabitConverter.from(habitEntity, habitAchievement, 3L);
+		}
+
 		return null;
 	}
 

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitAchievementUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitAchievementUseCase.java
@@ -60,6 +60,18 @@ public class SaveHabitAchievementUseCase {
 			return HabitConverter.from(habitEntity, habitAchievement, 3L);
 		}
 
+		if (achievementDate.isEqual(nextAchievementDate)) {
+			int dayDifference = calculateDayDifference(habitEntity, achievementDate);
+			HabitAchievementEntity savedHabitAchievementEntity =
+					habitAchievementRepository.save(
+							HabitAchievementConverter.to(
+									habitEntity, habitAchievementEntity, request, dayDifference));
+
+			HabitAchievement habitAchievement =
+					HabitAchievementConverter.from(savedHabitAchievementEntity);
+			return HabitConverter.from(habitEntity, habitAchievement, 3L);
+		}
+
 		return null;
 	}
 

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitUseCase.java
@@ -39,11 +39,9 @@ public class SaveHabitUseCase {
 		return HabitConverter.from(entity, data.getNotification());
 	}
 
-	private void saveAssociation(Long habitId, Notification data,
-			EnumSet<DayOfWeek> dayOfWeeks) {
+	private void saveAssociation(Long habitId, Notification data, EnumSet<DayOfWeek> dayOfWeeks) {
 		for (DayOfWeek dayOfWeek : dayOfWeeks) {
-			habitNotificationRepository.save(
-					HabitNotificationConverter.to(data, habitId, dayOfWeek));
+			habitNotificationRepository.save(HabitNotificationConverter.to(data, habitId, dayOfWeek));
 		}
 	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SearchHabitUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SearchHabitUseCase.java
@@ -52,10 +52,7 @@ public class SearchHabitUseCase {
 		HabitAchievement achievementData = this.calculateSequence(achievementEntity);
 		Long rewardCount = rewardHistoryRepository.countByHabitId(entity.getId());
 		Mate mateData =
-				mateRepository
-						.findByHabitId(entity.getId())
-						.map(MateConverter::from)
-						.orElse(null);
+				mateRepository.findByHabitId(entity.getId()).map(MateConverter::from).orElse(null);
 
 		return HabitConverter.from(entity, achievementData, rewardCount, mateData);
 	}

--- a/app/src/main/java/com/depromeet/threedays/front/repository/habit/HabitAchievementRepository.java
+++ b/app/src/main/java/com/depromeet/threedays/front/repository/habit/HabitAchievementRepository.java
@@ -4,9 +4,7 @@ import com.depromeet.threedays.data.entity.habit.HabitAchievementEntity;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface HabitAchievementRepository
-		extends JpaRepository<HabitAchievementEntity, Long> {
+public interface HabitAchievementRepository extends JpaRepository<HabitAchievementEntity, Long> {
 
-	Optional<HabitAchievementEntity> findFirstByHabitIdOrderByAchievementDateDesc(
-			final Long habitId);
+	Optional<HabitAchievementEntity> findFirstByHabitIdOrderByAchievementDateDesc(final Long habitId);
 }

--- a/app/src/main/java/com/depromeet/threedays/front/repository/notification/HabitNotificationRepository.java
+++ b/app/src/main/java/com/depromeet/threedays/front/repository/notification/HabitNotificationRepository.java
@@ -3,7 +3,4 @@ package com.depromeet.threedays.front.repository.notification;
 import com.depromeet.threedays.data.entity.notification.HabitNotificationEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface HabitNotificationRepository
-		extends JpaRepository<HabitNotificationEntity, Long> {
-
-}
+public interface HabitNotificationRepository extends JpaRepository<HabitNotificationEntity, Long> {}

--- a/data/src/main/java/com/depromeet/threedays/data/enums/DayOfWeek.java
+++ b/data/src/main/java/com/depromeet/threedays/data/enums/DayOfWeek.java
@@ -4,11 +4,21 @@ import lombok.Getter;
 
 @Getter
 public enum DayOfWeek {
-	MON,
-	TUE,
-	WED,
-	THU,
-	FRI,
-	SAT,
-	SUN
+	MON(1),
+	TUE(2),
+	WED(3),
+	THU(4),
+	FRI(5),
+	SAT(6),
+	SUN(7);
+
+	private final int value;
+
+	DayOfWeek(int value) {
+		this.value = value;
+	}
+
+	public int getValue() {
+		return value;
+	}
 }


### PR DESCRIPTION
💁‍♂️ PR 내용
----
어떤 습관에 대해 달성(체크) 요청을 보냈을 때, 

1. 달성 요청 날짜 < 예정 달성 날짜 
2. 달성 요청 날짜 = 예정 달성 날짜
3. 달성 요청 날짜 > 예정 달성 날짜

위 경우에 따른 achievementDate, nextAchievementDate, sequence의 변경이 적절히 이루어지도록 구현하였습니다. 
이와 동시에 sequence 값을 비교하여, RewardHistory를 추가하도록 구현하였습니다.

🙏 작업
----

**[AS-IS]**

**[TO-BE]**
1. 달성 요청 날짜 < 예정 달성 날짜
  - achievementDate = 요청 날짜
  - nextAchievementDate = 이전 달성 기록의 nextAchievementDate
  - sequence += 1

2. 달성 요청 날짜 = 예정 달성 날짜
  - achievementDate = 요청 날짜
  - nextAchievementDate = 습관에 지정되어 있는 다음 요일에 해당하는 날짜
  - sequence += 1

3. 달성 요청 날짜 > 예정 달성 날짜
  - achievementDate = 요청 날짜
  - nextAchievementDate = 습관에 지정되어 있는 다음 요일에 해당하는 날짜
  - sequence = 1로 초기화

sequence 개수가 3배수 일 때마다 RewardHistory를 생성하도록 구현
habitId 기준으로 RewardHistroy 개수를 조회하여 응답에 포함시켜 반환하도록 구현

📸 스크린샷
----
- HabitAchievement 테스트
습관 수행일을 월, 수, 금요일로 설정 했을때를 가정하여 테스트 진행
<img width="750" alt="image" src="https://user-images.githubusercontent.com/78407939/202376721-c9600caf-9d76-41d5-88f9-6716a15bc5cc.png">


- sequence 값에 따른 reward 반환값 테스트
<img width="361" alt="image" src="https://user-images.githubusercontent.com/78407939/202384077-c6be966b-6e94-4b55-b3c0-252a6cb1af3b.png">


