### PR TITLE
feat: 나의 기록(전체/상세) 조회 api 추가

### DIFF
--- a/app/src/main/resources/static/openapi3.yml
+++ b/app/src/main/resources/static/openapi3.yml
@@ -633,9 +633,6 @@ paths:
               example:
                 - code: "uncaught error"
                   message: "서버 에러"
-
-#                  RECORD
-
   /api/v1/me/records/{objectiveId}:
     get:
       tags:

--- a/app/src/main/resources/static/openapi3.yml
+++ b/app/src/main/resources/static/openapi3.yml
@@ -15,6 +15,8 @@ tags:
     description: 습관 성취
   - name: Mate
     description: 짝꿍
+  - name: Record
+    description: 기록
 paths:
   /api/v1/habits:
     post:
@@ -594,6 +596,82 @@ paths:
               example:
                 - code: "uncaught error"
                   message: "서버 에러"
+  /api/v1/records/monthly/{month}/{objectId}:
+    get:
+      tags:
+        - Record
+      summary: 박수, 수행일, 최다달성습관조회
+      operationId: getRecordFactsMonthly
+      description: 나의기록(전체)와 나의기록(상세)에서 모두 쓰입니다. 나의기록(전체)에서는 totalRewards와 totalAchievement가 null로 내려갑니다.
+      parameters:
+        - name: month
+          in: path
+          required: true
+          schema:
+            type: integer
+            enum: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ]
+        - name: objectId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordFacts'
+        '500':
+          description: INTERNAL SERVER ERROR
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiFailureResponse'
+              example:
+                - code: "uncaught error"
+                  message: "서버 에러"
+
+#                  RECORD
+
+  /api/v1/me/records/{objectiveId}:
+    get:
+      tags:
+        - Record
+      summary: 특정 목표의 상세 기록을 조회한다.
+      operationId: getRecordSingleObjective
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/RecordDetailResponse'
+        '400':
+          description: BAD REQUEST
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiFailureResponse'
+              example:
+                - code: "invalid.id"
+                  message: "id는 숫자여야만 합니다."
+        '500':
+          description: INTERNAL SERVER ERROR
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiFailureResponse'
+              example:
+                - code: "uncaught error"
+                  message: "서버 에러"
+
+
+
+
 security:
   - bearerAuth: [ token ]
 
@@ -691,6 +769,17 @@ components:
               type: integer
               format: int64
               example: 0
+    HabitLabel:
+      required: [habitId, title]
+      type: object
+      properties:
+        habitId:
+          type: integer
+          format: int64
+          example: 1
+        title:
+          type: string
+          example: "일어났니? 양치하고 얼른 물 마셔"
     SaveHabitRequest:
       required: [ title, imojiPath, dayOfWeeks, notification, color ]
       type: object
@@ -804,7 +893,6 @@ components:
           example: true
         token:
           $ref: '#/components/schemas/Token'
-
     Member:
       type: object
       properties:
@@ -839,6 +927,36 @@ components:
           type: string
           format: date-time
           example: 2022-10-10 12:34:56.789789
+    RecordFacts:
+      required: [ totalRewards, totalAchievements, monthlyRewards, monthlyAchievements, frequentHabit ]
+      properties:
+        totalRewards:
+          type: integer
+          format: int64
+          example: 4
+        totalAchievements:
+          type: integer
+          format: int64
+          example: 36
+        monthlyRewards:
+          type: integer
+          format: int64
+          example: 4
+        monthlyAchievements:
+          type: integer
+          format: int64
+          example: 36
+        frequentHabit:
+          $ref: '#/components/schemas/HabitLabel'
+    RecordDetailResponse:
+      required: [ habit, habitAchievementDate ]
+      type: object
+      properties:
+        habit:
+          $ref: '#/components/schemas/HabitProjection'
+        habitAchievementDate:
+          type: array
+          example: [ "2022-11-01", "2022-11-02", "2022-11-04", "2022-11-05", "2022-11-06" ]
     ApiResponse:
       type: object
       xml:

--- a/app/src/main/resources/static/openapi3.yml
+++ b/app/src/main/resources/static/openapi3.yml
@@ -596,7 +596,7 @@ paths:
               example:
                 - code: "uncaught error"
                   message: "서버 에러"
-  /api/v1/records/monthly/{month}/{objectId}:
+  /api/v1/records/me/monthly/{month}/{objectId}:
     get:
       tags:
         - Record
@@ -633,7 +633,7 @@ paths:
               example:
                 - code: "uncaught error"
                   message: "서버 에러"
-  /api/v1/me/records/{objectiveId}:
+  /api/v1/records/me/{objectiveId}:
     get:
       tags:
         - Record

--- a/app/src/main/resources/static/openapi3.yml
+++ b/app/src/main/resources/static/openapi3.yml
@@ -596,7 +596,7 @@ paths:
               example:
                 - code: "uncaught error"
                   message: "서버 에러"
-  /api/v1/records/me/summary/monthly/{month}/{habitId}:
+  /api/v1/habits/{habitId}/records/summary:
     get:
       tags:
         - Record
@@ -604,12 +604,18 @@ paths:
       operationId: getRecordFactsMonthly
       description: 나의기록(전체)와 나의기록(상세)에서 모두 쓰입니다. 나의기록(전체)에서는 totalRewards와 totalAchievement가 null로 내려갑니다.
       parameters:
-        - name: month
-          in: path
+        - name: to
+          in: query
           required: true
           schema:
-            type: integer
-            enum: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ]
+            type: string
+            format: date
+        - name: from
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date
         - name: habitId
           in: path
           required: true
@@ -632,19 +638,25 @@ paths:
               example:
                 - code: "uncaught error"
                   message: "서버 에러"
-  /api/v1/records/me/monthly/{month}/{habitId}:
+  /api/v1/habits/{habitId}/records:
     get:
       tags:
         - Record
       summary: 특정 목표의 상세 기록을 조회한다.
       operationId: getRecordSingleObjective
       parameters:
-        - name: month
-          in: path
+        - name: to
+          in: query
           required: true
           schema:
-            type: integer
-            enum: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ]
+            type: string
+            format: date
+        - name: from
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date
         - name: habitId
           in: path
           required: true
@@ -957,7 +969,7 @@ components:
       type: object
       properties:
         habit:
-          $ref: '#/components/schemas/HabitProjection'
+          $ref: '#/components/schemas/HabitOverview'
         habitAchievementDate:
           type: array
           example: [ "2022-11-01", "2022-11-02", "2022-11-04", "2022-11-05", "2022-11-06" ]

--- a/app/src/main/resources/static/openapi3.yml
+++ b/app/src/main/resources/static/openapi3.yml
@@ -596,7 +596,7 @@ paths:
               example:
                 - code: "uncaught error"
                   message: "서버 에러"
-  /api/v1/records/me/monthly/{month}/{objectId}:
+  /api/v1/records/me/summary/monthly/{month}/{habitId}:
     get:
       tags:
         - Record
@@ -610,13 +610,12 @@ paths:
           schema:
             type: integer
             enum: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ]
-        - name: objectId
+        - name: habitId
           in: path
           required: true
           schema:
             type: integer
             format: int64
-            example: 1
       responses:
         '200':
           description: OK
@@ -633,12 +632,25 @@ paths:
               example:
                 - code: "uncaught error"
                   message: "서버 에러"
-  /api/v1/records/me/{objectiveId}:
+  /api/v1/records/me/monthly/{month}/{habitId}:
     get:
       tags:
         - Record
       summary: 특정 목표의 상세 기록을 조회한다.
       operationId: getRecordSingleObjective
+      parameters:
+        - name: month
+          in: path
+          required: true
+          schema:
+            type: integer
+            enum: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ]
+        - name: habitId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
       responses:
         '200':
           description: OK

--- a/app/src/main/resources/static/openapi3.yml
+++ b/app/src/main/resources/static/openapi3.yml
@@ -780,7 +780,7 @@ components:
         createAt:
           type: string
           example: "2022-10-15T10:30:00.000"
-            todayHabitAchievement:
+        todayHabitAchievement:
           type: object
           properties:
             habitAchievementId:

--- a/app/src/main/resources/static/openapi3.yml
+++ b/app/src/main/resources/static/openapi3.yml
@@ -610,12 +610,14 @@ paths:
           schema:
             type: string
             format: date
+            example: 2022-11-01
         - name: from
           in: query
           required: true
           schema:
             type: string
             format: date
+            example: 2022-11-30
         - name: habitId
           in: path
           required: true
@@ -651,12 +653,14 @@ paths:
           schema:
             type: string
             format: date
+            example: 2022-11-01
         - name: from
           in: query
           required: true
           schema:
             type: string
             format: date
+            example: 2022-11-30
         - name: habitId
           in: path
           required: true


### PR DESCRIPTION
💁‍♂️ PR 내용
----
 *  `/api/v1/records/me/summary/monthly/{month}/{habitId}`
유저의 토큰과 해당 달, habitId를 받아
1. 나의기록(전체): 유저의 월별박수, 월별수행횟수, 가장많이수행한습관을 return(총박수와 총수행횟수는 null)  
2. 나의기록(상세): 목표의 월별박수, 월별수행횟수, 총박수, 총수행횟수를 return (가장 많이 수행한 습관은 null)  
 
  
* `api/v1/records/me/monthly/{month}/{habitId}`
나의기록(상세)에서 유저의 토큰과 해당 달, habitId를 받아  
HabitProjection 객체와 습관수행일리스트를 내린다.


📸 스크린샷
----

나의기록
![image](https://user-images.githubusercontent.com/45715824/203053990-6ae99cb6-73b4-43eb-ade6-2e8e2e390df2.png)



나의기록(상세)
![image](https://user-images.githubusercontent.com/45715824/203053909-9db209fd-bfdf-4f23-8c47-1f4a4a9088c8.png)

