### PR TITLE
DEP-164 feat : token and security setting

### DIFF
--- a/app/src/main/java/com/depromeet/threedays/front/config/security/SecurityConfig.java
+++ b/app/src/main/java/com/depromeet/threedays/front/config/security/SecurityConfig.java
@@ -31,9 +31,7 @@ public class SecurityConfig {
 		http.formLogin().disable();
 		http.httpBasic().disable();
 		http.authorizeRequests()
-				.antMatchers("/swagger-ui/index.html#/")
-				.permitAll()
-				.antMatchers("/api/v1/**")
+				.anyRequest()
 				.permitAll();
 
 		http.addFilterAt(

--- a/app/src/main/java/com/depromeet/threedays/front/config/security/SecurityConfig.java
+++ b/app/src/main/java/com/depromeet/threedays/front/config/security/SecurityConfig.java
@@ -30,9 +30,7 @@ public class SecurityConfig {
 		http.csrf().disable();
 		http.formLogin().disable();
 		http.httpBasic().disable();
-		http.authorizeRequests()
-				.anyRequest()
-				.permitAll();
+		http.authorizeRequests().anyRequest().permitAll();
 
 		http.addFilterAt(
 				generateAuthenticationFilter(), AbstractPreAuthenticatedProcessingFilter.class);

--- a/app/src/main/java/com/depromeet/threedays/front/config/security/SecurityConfig.java
+++ b/app/src/main/java/com/depromeet/threedays/front/config/security/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig {
 	private final TokenResolver tokenResolver;
 
 	@Bean
-	@Profile({"local", "integration-test", "default"})
+	@Profile({"local", "integration-test"})
 	public SecurityFilterChain localSecurityFilterChain(HttpSecurity http) throws Exception {
 		http.csrf().disable();
 		http.formLogin().disable();
@@ -36,6 +36,9 @@ public class SecurityConfig {
 				.antMatchers("/api/v1/**")
 				.permitAll();
 
+		http.addFilterAt(
+				generateAuthenticationFilter(), AbstractPreAuthenticatedProcessingFilter.class);
+
 		http.exceptionHandling()
 				.authenticationEntryPoint(authenticationEntryPoint)
 				.accessDeniedHandler(accessDeniedHandler);
@@ -45,7 +48,7 @@ public class SecurityConfig {
 	}
 
 	@Bean
-	@Profile(value = "prod")
+	@Profile(value = "default")
 	public SecurityFilterChain prodSecurityFilterChain(HttpSecurity http) throws Exception {
 		http.csrf().disable();
 		http.formLogin().disable();
@@ -54,7 +57,7 @@ public class SecurityConfig {
 		http.authorizeRequests()
 				.antMatchers("/swagger-ui/index.html#/")
 				.permitAll()
-				.antMatchers("/api/v1/**")
+				.antMatchers("/api/v1/members")
 				.permitAll()
 				.anyRequest()
 				.authenticated();

--- a/app/src/main/java/com/depromeet/threedays/front/support/TokenGenerator.java
+++ b/app/src/main/java/com/depromeet/threedays/front/support/TokenGenerator.java
@@ -19,7 +19,6 @@ public class TokenGenerator {
 	@Value("${security.jwt.token.validtime}")
 	private Long tokenValidTime;
 
-
 	private static final String MEMBER_ID_CLAIM_KEY = "memberId";
 
 	public String generateAccessToken(Long memberId) {

--- a/app/src/main/java/com/depromeet/threedays/front/support/TokenGenerator.java
+++ b/app/src/main/java/com/depromeet/threedays/front/support/TokenGenerator.java
@@ -13,10 +13,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class TokenGenerator {
 	@Value("${security.jwt.token.secretkey}")
-	private String SECRET_KEY;
+	private String secretKey;
 
 	@Value("${security.jwt.token.validtime}")
-	private Long TOKEN_VALID_TIME;
+	private Long tokenValidTime;
 
 	private static final String MEMBER_ID_CLAIM_KEY = "memberId";
 
@@ -27,8 +27,8 @@ public class TokenGenerator {
 				.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
 				.claim(MEMBER_ID_CLAIM_KEY, memberId)
 				.setIssuedAt(now)
-				.setExpiration(new Date(now.getTime() + TOKEN_VALID_TIME))
-				.signWith(Keys.hmacShaKeyFor(SECRET_KEY.getBytes()))
+				.setExpiration(new Date(now.getTime() + tokenValidTime))
+				.signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
 				.compact();
 	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/support/TokenGenerator.java
+++ b/app/src/main/java/com/depromeet/threedays/front/support/TokenGenerator.java
@@ -16,7 +16,7 @@ public class TokenGenerator {
 	private String SECRET_KEY;
 
 	@Value("${security.jwt.token.validtime}")
-	private Integer TOKEN_VALID_TIME;
+	private Long TOKEN_VALID_TIME;
 
 	private static final String MEMBER_ID_CLAIM_KEY = "memberId";
 


### PR DESCRIPTION
💁‍♂️ PR 내용
----
- local 환경에서도 security context에 token의 id를 저장하고 조회할 수 있도록 필터를 추가하였습니다.
  - local 환경에서 api 접근에 대한 권한은 모두 허용하였습니다.
- prod(default) 환경에서 api 요청 인증에 대한 처리를 추가하였습니다.
- 유효기간 1년의 prod(default)용 토큰 생성하였습니다.

🙏 작업
----
**[AS-IS]**
1. local 인증 필터 X
2. @Profile("prod")
3. prod(default)의 `/api/vi/**` 요청에 대한 인증이 `permitAll()` 

**[TO-BE]**
1. local에 인증 필터 추가하였습니다.
2. @Profile("default")로 변경하였습니다.
3. 로그인/회원가입과 swagger api를 제외한 나머지 api 요청은 토큰 인증이 필요하도록 변경하였습니다.

🤖 테스트 체크리스트
----
- [x] Postman을 이용하여 테스트

