### PR TITLE
DEP-141 멤버 탈퇴 api 추가

### DIFF
--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/data/habit/FakeHabitEntity.java
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/data/habit/FakeHabitEntity.java
@@ -23,5 +23,17 @@ public class FakeHabitEntity {
 				.deleted(false)
 				.build();
 	}
+	static HabitEntity create(Long memberId) {
+		return HabitEntity.builder()
+				.imojiPath(RandomString.make())
+				.memberId(memberId)
+				.title(RandomString.make())
+				.dayOfWeeks(dayOfWeeks)
+				.archiveNumberOfDate(0)
+				.color(RandomString.make())
+				.status(HabitStatus.ACTIVE)
+				.deleted(false)
+				.build();
+	}
 
 }

--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/data/habit/HabitDataInitializer.groovy
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/data/habit/HabitDataInitializer.groovy
@@ -3,6 +3,7 @@ package com.depromeet.threedays.front.data.habit
 import com.depromeet.threedays.data.entity.habit.HabitEntity
 import com.depromeet.threedays.data.entity.mate.MateEntity
 import com.depromeet.threedays.data.enums.MateType
+import com.depromeet.threedays.front.data.mate.FakeMateEntity
 import com.depromeet.threedays.front.persistence.repository.habit.HabitRepository
 import com.depromeet.threedays.front.persistence.repository.mate.MateRepository
 import net.bytebuddy.utility.RandomString
@@ -29,6 +30,14 @@ class HabitDataInitializer {
 
         this.setData()
         this.setAssociation(data.first().id)
+    }
+
+    void initialize(Long memberId) {
+        repository.deleteAll()
+        this.save(memberId)
+    }
+    private void save(Long memberId) {
+        this.data = repository.save(FakeHabitEntity.create(memberId))
     }
 
     Collection<HabitEntity> getData() {

--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/data/member/MemberDataInitializer.groovy
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/data/member/MemberDataInitializer.groovy
@@ -1,10 +1,17 @@
 package com.depromeet.threedays.front.data.member
 
+import com.depromeet.threedays.data.entity.habit.HabitEntity
 import com.depromeet.threedays.data.entity.member.MemberEntity
+import com.depromeet.threedays.data.enums.HabitStatus
 import com.depromeet.threedays.front.data.habit.FakeMemberEntity
+import com.depromeet.threedays.front.persistence.repository.habit.HabitRepository
 import com.depromeet.threedays.front.persistence.repository.member.MemberRepository
+import net.bytebuddy.utility.RandomString
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+
+import java.time.DayOfWeek
+
 
 @Component
 class MemberDataInitializer {
@@ -13,11 +20,16 @@ class MemberDataInitializer {
     @Autowired
     private MemberRepository repository
 
+    @Autowired
+    private HabitRepository habitRepository
+
     private Collection<MemberEntity> data
+    private HabitEntity associationData
 
     void initialize() {
         repository.deleteAll()
         this.setData()
+        this.setAssociation(data.first().id)
     }
 
     Collection<MemberEntity> getData() {
@@ -30,5 +42,22 @@ class MemberDataInitializer {
             data.add(repository.save(FakeMemberEntity.create()))
         }
         this.data = data
+    }
+
+    private void setAssociation(final Long memberId) {
+        def dayOfWeeks = EnumSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY,
+                DayOfWeek.SUNDAY)
+        def habitEntity = HabitEntity.builder()
+                .imojiPath(RandomString.make())
+                .memberId(memberId)
+                .title(RandomString.make())
+                .dayOfWeeks(dayOfWeeks)
+                .archiveNumberOfDate(0)
+                .color(RandomString.make())
+                .status(HabitStatus.ACTIVE)
+                .deleted(false)
+                .build()
+
+        this.associationData = habitRepository.save(habitEntity)
     }
 }

--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/member/DeleteMemberUseCaseSpec.groovy
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/member/DeleteMemberUseCaseSpec.groovy
@@ -1,0 +1,68 @@
+package com.depromeet.threedays.front.domain.usecase.member
+
+
+import com.depromeet.threedays.front.IntegrationTestSpecification
+import com.depromeet.threedays.front.data.habit.HabitDataInitializer
+import com.depromeet.threedays.front.data.member.MemberDataInitializer
+import com.depromeet.threedays.front.persistence.repository.RewardHistoryRepository
+import com.depromeet.threedays.front.persistence.repository.client.ClientRepository
+import com.depromeet.threedays.front.persistence.repository.habit.HabitAchievementRepository
+import com.depromeet.threedays.front.persistence.repository.habit.HabitRepository
+import com.depromeet.threedays.front.persistence.repository.mate.MateRepository
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository
+import com.depromeet.threedays.front.persistence.repository.notification.HabitNotificationRepository
+import org.springframework.beans.factory.annotation.Autowired
+
+class DeleteMemberUseCaseSpec extends IntegrationTestSpecification {
+
+
+    DeleteMemberUseCase useCase
+    MemberRepository memberRepository
+
+    @Autowired
+    MemberDataInitializer initializer
+    @Autowired
+    HabitDataInitializer habitDataInitializer
+
+
+    ClientRepository clientRepository
+    HabitRepository habitRepository
+    HabitNotificationRepository habitNotificationRepository
+    RewardHistoryRepository rewardHistoryRepository
+    HabitAchievementRepository habitAchievementRepository
+    MateRepository mateRepository
+
+    def setup() {
+        initializer.initialize()
+        habitDataInitializer.initialize()
+
+
+        memberRepository = Mock(MemberRepository.class)
+        clientRepository = Mock(ClientRepository.class)
+        habitRepository = Mock(HabitRepository.class)
+        habitNotificationRepository = Mock(HabitNotificationRepository)
+        rewardHistoryRepository = Mock(RewardHistoryRepository.class)
+        habitAchievementRepository = Mock(HabitAchievementRepository.class)
+        mateRepository = Mock(MateRepository.class)
+
+        useCase = new DeleteMemberUseCase(memberRepository, clientRepository,
+                habitRepository, habitNotificationRepository, rewardHistoryRepository,
+                habitAchievementRepository, mateRepository)
+
+    }
+
+    def "사용자를 삭제하면 습관이 삭제된다."() {
+        setup:
+        def criterionMember = initializer.data.first()
+        habitDataInitializer.initialize()
+        def criterion = habitDataInitializer.getData()
+
+        when:
+        useCase.execute()
+        habitRepository.findById(criterion.id).get()
+
+        then:
+        memberRepository.findById(_) >> Optional.of(criterionMember)
+        thrown(NullPointerException)
+    }
+}

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/member/DeleteMemberUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/member/DeleteMemberUseCase.java
@@ -1,0 +1,48 @@
+package com.depromeet.threedays.front.domain.usecase.member;
+
+import com.depromeet.threedays.data.entity.member.MemberEntity;
+import com.depromeet.threedays.front.config.security.AuditorHolder;
+import com.depromeet.threedays.front.persistence.repository.RewardHistoryRepository;
+import com.depromeet.threedays.front.persistence.repository.client.ClientRepository;
+import com.depromeet.threedays.front.persistence.repository.habit.HabitAchievementRepository;
+import com.depromeet.threedays.front.persistence.repository.habit.HabitRepository;
+import com.depromeet.threedays.front.persistence.repository.mate.MateRepository;
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository;
+import com.depromeet.threedays.front.persistence.repository.notification.HabitNotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class DeleteMemberUseCase {
+
+	private final MemberRepository memberRepository;
+	private final ClientRepository clientRepository;
+	private final HabitRepository habitRepository;
+	private final HabitNotificationRepository habitNotificationRepository;
+	private final RewardHistoryRepository rewardHistoryRepository;
+	private final HabitAchievementRepository habitAchievementRepository;
+	private final MateRepository mateRepository;
+
+	public void execute() {
+		Long memberId = AuditorHolder.get();
+
+		MemberEntity source = memberRepository.findById(memberId).orElse(null);
+		if (source == null) {
+			return;
+		}
+
+		mateRepository.deleteAllByMemberId(source.getId());
+
+		habitAchievementRepository.deleteAllByMemberId(source.getId());
+		rewardHistoryRepository.deleteAllByMemberId(source.getId());
+		habitNotificationRepository.deleteAllByMemberId(source.getId());
+		habitRepository.deleteAllByMemberId(source.getId());
+
+		clientRepository.deleteAllByMemberId(source.getId());
+
+		memberRepository.deleteById(source.getId());
+	}
+}

--- a/app/src/main/java/com/depromeet/threedays/front/persistence/repository/RewardHistoryRepository.java
+++ b/app/src/main/java/com/depromeet/threedays/front/persistence/repository/RewardHistoryRepository.java
@@ -15,4 +15,6 @@ public interface RewardHistoryRepository extends JpaRepository<RewardHistoryEnti
 			final Long habitId, final LocalDateTime createAt);
 
 	void deleteFirstByHabitIdOrderByCreateAtDesc(final Long habitId);
+
+	void deleteAllByMemberId(final Long memberId);
 }

--- a/app/src/main/java/com/depromeet/threedays/front/persistence/repository/client/ClientRepository.java
+++ b/app/src/main/java/com/depromeet/threedays/front/persistence/repository/client/ClientRepository.java
@@ -8,4 +8,6 @@ public interface ClientRepository extends JpaRepository<ClientEntity, Long> {
 
 	Optional<ClientEntity> findByMemberIdAndIdentificationKey(
 			final Long MemberId, final String identificationKey);
+
+	void deleteAllByMemberId(Long memberId);
 }

--- a/app/src/main/java/com/depromeet/threedays/front/persistence/repository/habit/HabitAchievementRepository.java
+++ b/app/src/main/java/com/depromeet/threedays/front/persistence/repository/habit/HabitAchievementRepository.java
@@ -14,4 +14,6 @@ public interface HabitAchievementRepository extends JpaRepository<HabitAchieveme
 
 	List<HabitAchievementEntity> findAllByHabitIdAndAchievementDateBetween(
 			final Long habitId, final LocalDate startDate, final LocalDate endDate);
+
+	void deleteAllByMemberId(final Long memberId);
 }

--- a/app/src/main/java/com/depromeet/threedays/front/persistence/repository/habit/HabitRepository.java
+++ b/app/src/main/java/com/depromeet/threedays/front/persistence/repository/habit/HabitRepository.java
@@ -14,4 +14,6 @@ public interface HabitRepository extends JpaRepository<HabitEntity, Long> {
 	Optional<HabitEntity> findByIdAndDeletedFalse(final Long habitId);
 
 	Boolean existsByIdAndDeletedFalse(final Long id);
+
+	void deleteAllByMemberId(final Long memberId);
 }

--- a/app/src/main/java/com/depromeet/threedays/front/persistence/repository/mate/MateRepository.java
+++ b/app/src/main/java/com/depromeet/threedays/front/persistence/repository/mate/MateRepository.java
@@ -13,4 +13,6 @@ public interface MateRepository extends JpaRepository<MateEntity, Long> {
 	Boolean existsByMemberIdAndDeletedFalse(final Long habitId);
 
 	Optional<MateEntity> findFirstByHabitIdOrderByCreateAtDesc(final Long habitId);
+
+	void deleteAllByMemberId(final Long memberId);
 }

--- a/app/src/main/java/com/depromeet/threedays/front/persistence/repository/notification/HabitNotificationRepository.java
+++ b/app/src/main/java/com/depromeet/threedays/front/persistence/repository/notification/HabitNotificationRepository.java
@@ -12,4 +12,6 @@ public interface HabitNotificationRepository extends JpaRepository<HabitNotifica
 
 	Optional<HabitNotificationEntity> findAllByNotificationTimeAndDayOfWeek(
 			final LocalTime notificationTime, final DayOfWeek dayOfWeek);
+
+	void deleteAllByMemberId(final Long memberId);
 }

--- a/app/src/main/java/com/depromeet/threedays/front/web/controller/MemberController.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/controller/MemberController.java
@@ -15,11 +15,7 @@ import com.depromeet.threedays.front.web.response.SaveMemberResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/api/v1/members")
 @RequiredArgsConstructor
@@ -33,6 +29,7 @@ public class MemberController {
 	private final SaveConsentUseCase saveConsentUseCase;
 	private final SaveResourceUseCase saveResourceUseCase;
 	private final GetTokenUseCase getTokenUseCase;
+	private final DeleteMemberUseCase deleteUseCase;
 
 	@PostMapping
 	public ApiResponse<SaveMemberResponse> add(@RequestBody @Valid SignMemberRequest request) {
@@ -61,5 +58,11 @@ public class MemberController {
 	@PostMapping("/tokens")
 	public ApiResponse<Token> refreshToken(@RequestBody Token token) {
 		return ApiResponseGenerator.success(getTokenUseCase.execute(token), HttpStatus.CREATED);
+	}
+
+	@DeleteMapping
+	public ApiResponse<Void> deleteMember() {
+		deleteUseCase.execute();
+		return ApiResponseGenerator.success(HttpStatus.NO_CONTENT);
 	}
 }


### PR DESCRIPTION
💁‍♂️ PR 내용
----
* 충돌이 있어 원복해 올립니다. 
* Member를 삭제하는 탈퇴 api입니다. 
* 관련된 데이터인 client, habit, habitNotification, rewardHistory, habitAchievement, mate를 모두 찾아 완전히 삭제합니다. 
* response httpstatus는 204 NO_CONTENT입니다.


🤖 테스트 체크리스트
----
- [x] 멤버 탈퇴 시 습관 삭제 확인 완료
- [x] lint
