### PR TITLE
DEP-131 save Notification History

### DIFF
--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/member/DeleteMemberUseCaseSpec.groovy
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/member/DeleteMemberUseCaseSpec.groovy
@@ -55,11 +55,10 @@ class DeleteMemberUseCaseSpec extends IntegrationTestSpecification {
         setup:
         def criterionMember = initializer.data.first()
         habitDataInitializer.initialize()
-        def criterion = habitDataInitializer.getData()
 
         when:
         useCase.execute()
-        habitRepository.findById(criterion.id as Long).get()
+        habitRepository.findById(criterionMember.id as Long).get()
 
         then:
         memberRepository.findById(_ as Long) >> Optional.of(criterionMember)

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/notification/GlobalNotificationConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/notification/GlobalNotificationConverter.java
@@ -18,6 +18,7 @@ public class GlobalNotificationConverter {
 
 	public static NotificationMessage from(GlobalNotificationEntity entity) {
 		return NotificationMessage.builder()
+				.notificationId(entity.getId())
 				.contents(entity.getContents())
 				.notificationTime(entity.getNotificationTime())
 				.title(entity.getTitle())

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/notification/HabitNotificationConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/notification/HabitNotificationConverter.java
@@ -31,12 +31,13 @@ public class HabitNotificationConverter {
 				.build();
 	}
 
-	public static HabitNotificationMessage habitMessagefrom(HabitNotificationEntity entity) {
+	public static HabitNotificationMessage habitMessageFrom(HabitNotificationEntity entity) {
 		if (entity == null) {
 			return null;
 		}
 
 		return HabitNotificationMessage.builder()
+				.notificationId(entity.getId())
 				.habitId(entity.getHabitId())
 				.content(entity.getContents())
 				.notificationTime(entity.getNotificationTime())

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/notification/NotificationHistoryConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/notification/NotificationHistoryConverter.java
@@ -1,0 +1,32 @@
+package com.depromeet.threedays.front.domain.converter.notification;
+
+import com.depromeet.threedays.data.entity.client.ClientEntity;
+import com.depromeet.threedays.data.entity.history.NotificationHistoryEntity;
+import com.depromeet.threedays.data.enums.NotificationStatus;
+import com.depromeet.threedays.front.domain.model.client.Client;
+import com.depromeet.threedays.front.domain.model.notification.HabitNotificationMessage;
+import com.depromeet.threedays.front.domain.model.notification.NotificationMessage;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class NotificationHistoryConverter {
+	public static NotificationHistoryEntity from(
+			NotificationMessage message, ClientEntity client, NotificationStatus status) {
+		return NotificationHistoryEntity.builder()
+				.notificationId(message.getNotificationId())
+				.contents(message.getContents())
+				.status(status)
+				.memberId(client.getMemberId())
+				.build();
+	}
+
+	public static NotificationHistoryEntity from(
+			HabitNotificationMessage message, Client client, NotificationStatus status) {
+		return NotificationHistoryEntity.builder()
+				.notificationId(message.getNotificationId())
+				.contents(message.getContent())
+				.status(status)
+				.memberId(client.getMemberId())
+				.build();
+	}
+}

--- a/app/src/main/java/com/depromeet/threedays/front/domain/model/notification/HabitNotificationMessage.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/model/notification/HabitNotificationMessage.java
@@ -11,6 +11,7 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor
 public class HabitNotificationMessage {
+	private Long notificationId;
 	private Long memberId;
 	private List<Client> clients;
 	private Long habitId;

--- a/app/src/main/java/com/depromeet/threedays/front/domain/model/notification/NotificationMessage.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/model/notification/NotificationMessage.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class NotificationMessage {
+	private Long notificationId;
 	private LocalTime notificationTime;
 	private String contents;
 	private String title;

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitAchievementUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitAchievementUseCase.java
@@ -46,8 +46,7 @@ public class SaveHabitAchievementUseCase {
 
 		final HabitAchievement lastHabitAchievement =
 				HabitAchievementConverter.to(
-						repository.findFirstByHabitIdOrderByAchievementDateDesc(habitId)
-								.orElse(null));
+						repository.findFirstByHabitIdOrderByAchievementDateDesc(habitId).orElse(null));
 
 		final Mate mate =
 				mateRepository
@@ -63,8 +62,7 @@ public class SaveHabitAchievementUseCase {
 					this.save(
 							habit,
 							request,
-							DateCalculator.findNextDate(habit.getDayOfWeeks(),
-									request.getAchievementDate()),
+							DateCalculator.findNextDate(habit.getDayOfWeeks(), request.getAchievementDate()),
 							1),
 					0L);
 		}
@@ -82,8 +80,7 @@ public class SaveHabitAchievementUseCase {
 					this.save(
 							habit,
 							request,
-							DateCalculator.findNextDate(habit.getDayOfWeeks(),
-									request.getAchievementDate()),
+							DateCalculator.findNextDate(habit.getDayOfWeeks(), request.getAchievementDate()),
 							1),
 					getTotalRewardCount(habit, 1));
 		}
@@ -96,8 +93,7 @@ public class SaveHabitAchievementUseCase {
 					this.save(
 							habit,
 							request,
-							DateCalculator.findNextDate(habit.getDayOfWeeks(),
-									request.getAchievementDate()),
+							DateCalculator.findNextDate(habit.getDayOfWeeks(), request.getAchievementDate()),
 							sequence),
 					getTotalRewardCount(habit, sequence),
 					updateMateLevel(habit, sequence));
@@ -117,8 +113,7 @@ public class SaveHabitAchievementUseCase {
 			int sequence) {
 		HabitAchievementEntity entity =
 				repository.save(
-						HabitAchievementConverter.to(habit, request, nextAchievementDate,
-								sequence));
+						HabitAchievementConverter.to(habit, request, nextAchievementDate, sequence));
 		return HabitAchievementConverter.from(entity);
 	}
 
@@ -146,7 +141,7 @@ public class SaveHabitAchievementUseCase {
 
 		Long rewardCount =
 				rewardHistoryRepository.countByHabitIdAndCreateAtIsAfter(
-						habit.getMemberId(), mate.getCreateAt())
+								habit.getMemberId(), mate.getCreateAt())
 						+ 1;
 
 		if (this.isLevelUp(rewardCount)) {
@@ -154,8 +149,7 @@ public class SaveHabitAchievementUseCase {
 					mateRepository.save(
 							MateConverter.to(
 									mate.toBuilder()
-											.level(LevelUpSection.MATE.getSectionMap()
-													.get(rewardCount))
+											.level(LevelUpSection.MATE.getSectionMap().get(rewardCount))
 											.levelUpAt(LocalDateTime.now())
 											.build())));
 		}

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/mate/GetMateUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/mate/GetMateUseCase.java
@@ -50,5 +50,4 @@ public class GetMateUseCase {
 				.withRewardHistory(rewardHistories)
 				.withLevelUpSection(LevelUpSection.MATE.getSectionList());
 	}
-
 }

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/notification/SaveNotificationHistoryUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/notification/SaveNotificationHistoryUseCase.java
@@ -22,7 +22,7 @@ public class SaveNotificationHistoryUseCase {
 
 	public void execute(int successCount, NotificationMessage message, List<ClientEntity> group) {
 		if (successCount == 0) {
-			repository.saveAll(createList(NotificationStatus.SUCCESS, message, group));
+			repository.saveAll(createList(NotificationStatus.SENT, message, group));
 		} else {
 			repository.saveAll(createList(NotificationStatus.FAILURE, message, group));
 		}
@@ -32,7 +32,7 @@ public class SaveNotificationHistoryUseCase {
 		if (successCount == 0) {
 			repository.saveAll(createList(NotificationStatus.FAILURE, message));
 		} else {
-			repository.saveAll(createList(NotificationStatus.SUCCESS, message));
+			repository.saveAll(createList(NotificationStatus.SENT, message));
 		}
 	}
 

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/notification/SaveNotificationHistoryUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/notification/SaveNotificationHistoryUseCase.java
@@ -1,0 +1,52 @@
+package com.depromeet.threedays.front.domain.usecase.notification;
+
+import com.depromeet.threedays.data.entity.client.ClientEntity;
+import com.depromeet.threedays.data.entity.history.NotificationHistoryEntity;
+import com.depromeet.threedays.data.enums.NotificationStatus;
+import com.depromeet.threedays.front.domain.converter.notification.NotificationHistoryConverter;
+import com.depromeet.threedays.front.domain.model.notification.HabitNotificationMessage;
+import com.depromeet.threedays.front.domain.model.notification.NotificationMessage;
+import com.depromeet.threedays.front.persistence.repository.notification.NotificationHistoryRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class SaveNotificationHistoryUseCase {
+
+	private final NotificationHistoryRepository repository;
+
+	public void execute(int successCount, NotificationMessage message, List<ClientEntity> group) {
+		if (successCount == 0) {
+			repository.saveAll(createList(NotificationStatus.SUCCESS, message, group));
+		} else {
+			repository.saveAll(createList(NotificationStatus.FAILURE, message, group));
+		}
+	}
+
+	public void execute(int successCount, HabitNotificationMessage message) {
+		if (successCount == 0) {
+			repository.saveAll(createList(NotificationStatus.FAILURE, message));
+		} else {
+			repository.saveAll(createList(NotificationStatus.SUCCESS, message));
+		}
+	}
+
+	public List<NotificationHistoryEntity> createList(
+			NotificationStatus status, NotificationMessage message, List<ClientEntity> group) {
+		return group.stream()
+				.map(c -> NotificationHistoryConverter.from(message, c, status))
+				.collect(Collectors.toList());
+	}
+
+	public List<NotificationHistoryEntity> createList(
+			NotificationStatus status, HabitNotificationMessage message) {
+		return message.getClients().stream()
+				.map(c -> NotificationHistoryConverter.from(message, c, status))
+				.collect(Collectors.toList());
+	}
+}

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/notification/SaveNotificationHistoryUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/notification/SaveNotificationHistoryUseCase.java
@@ -22,7 +22,7 @@ public class SaveNotificationHistoryUseCase {
 
 	public void execute(int successCount, NotificationMessage message, List<ClientEntity> group) {
 		if (successCount == 0) {
-			repository.saveAll(createList(NotificationStatus.SENT, message, group));
+			repository.saveAll(createList(NotificationStatus.SUCCESS, message, group));
 		} else {
 			repository.saveAll(createList(NotificationStatus.FAILURE, message, group));
 		}
@@ -32,7 +32,7 @@ public class SaveNotificationHistoryUseCase {
 		if (successCount == 0) {
 			repository.saveAll(createList(NotificationStatus.FAILURE, message));
 		} else {
-			repository.saveAll(createList(NotificationStatus.SENT, message));
+			repository.saveAll(createList(NotificationStatus.SUCCESS, message));
 		}
 	}
 

--- a/app/src/main/java/com/depromeet/threedays/front/persistence/repository/notification/NotificationHistoryRepository.java
+++ b/app/src/main/java/com/depromeet/threedays/front/persistence/repository/notification/NotificationHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.depromeet.threedays.front.persistence.repository.notification;
+
+import com.depromeet.threedays.data.entity.history.NotificationHistoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationHistoryRepository
+		extends JpaRepository<NotificationHistoryEntity, Long> {}

--- a/app/src/main/java/com/depromeet/threedays/front/support/NotificationLogger.java
+++ b/app/src/main/java/com/depromeet/threedays/front/support/NotificationLogger.java
@@ -1,10 +1,10 @@
 package com.depromeet.threedays.front.support;
 
+import com.depromeet.threedays.front.domain.model.notification.HabitNotificationMessage;
 import com.depromeet.threedays.front.domain.model.notification.NotificationMessage;
 import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.SendResponse;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
@@ -12,19 +12,25 @@ import lombok.extern.slf4j.Slf4j;
 @UtilityClass
 public class NotificationLogger {
 
-	public static void messagesLogger(List<NotificationMessage> messages) {
-		log.info("=====SEND MESSAGE=====");
-		for (NotificationMessage message : messages) {
-			log.info(
-					"title:{}, contents:{}, notification_time:{}",
-					message.getTitle(),
-					message.getContents(),
-					message.getNotificationTime());
-		}
+	public static void messagesLogger(NotificationMessage message) {
+		log.info(
+				"===prepare to sending globalNoti=== title:{}, contents:{}, notification_time:{}",
+				message.getTitle(),
+				message.getContents(),
+				message.getNotificationTime());
+	}
+
+	public static void messagesLogger(HabitNotificationMessage habitMessage) {
+		log.info(
+				"===prepare to sending habitNoti=== member:{}, habit:{}, content:{}, notification_time:{}",
+				habitMessage.getMemberId(),
+				habitMessage.getHabitId(),
+				habitMessage.getContent(),
+				habitMessage.getNotificationTime());
 	}
 
 	public static void batchResponseLogger(BatchResponse response) {
-		log.info("=====SEND RESULT=====");
+		log.info("===sending completed===");
 		for (SendResponse r : response.getResponses()) {
 			log.info(
 					"messageId: {}, exception:{}, successful:{}",

--- a/app/src/main/java/com/depromeet/threedays/front/support/converter/MemberInfoJsonConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/support/converter/MemberInfoJsonConverter.java
@@ -13,9 +13,8 @@ import org.json.simple.parser.ParseException;
 @UtilityClass
 public class MemberInfoJsonConverter {
 
-	private static final ObjectMapper objectMapper = new ObjectMapper().setSerializationInclusion(
-			JsonInclude.Include.NON_NULL);
-
+	private static final ObjectMapper objectMapper =
+			new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
 	public static String to(MemberInfo info) {
 		try {

--- a/data/src/main/java/com/depromeet/threedays/data/enums/NotificationStatus.java
+++ b/data/src/main/java/com/depromeet/threedays/data/enums/NotificationStatus.java
@@ -1,6 +1,7 @@
 package com.depromeet.threedays.data.enums;
 
 public enum NotificationStatus {
-	SUCCESS,
-	FAILURE
+	SENT,
+	FAILURE,
+	CHECKED
 }

--- a/data/src/main/java/com/depromeet/threedays/data/enums/NotificationStatus.java
+++ b/data/src/main/java/com/depromeet/threedays/data/enums/NotificationStatus.java
@@ -1,7 +1,7 @@
 package com.depromeet.threedays.data.enums;
 
 public enum NotificationStatus {
-	SENT,
+	SUCCESS,
 	FAILURE,
 	CHECKED
 }


### PR DESCRIPTION
💁‍♂️ PR 내용
----
notification 발송 이후 history를 저장합니다. 
1. Batch로 발송된 메세지 전부가 실패하면, 해당 메세지 전부를 FAILED로 기록합니다. 
2. Batch로 발송된 메세지 중 하나라도 성공하면, 해당 메세지 전부를 SUCCESS로 기록합니다.3. 

메세지 발송 전에는 메세지 데이터를, 발송 후에는 결과를 로그로 출력합니다. 

🙏 작업
----
SaveNotificationUseCase
NotificationLogger 수정


🤖 테스트 체크리스트
----
- [x] 수동 테스트
- [x] lint
