### PR TITLE
fix: Add notification type

### DIFF
--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/member/SaveMemberConsentUseCaseSpec.groovy
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/member/SaveMemberConsentUseCaseSpec.groovy
@@ -21,7 +21,7 @@ class SaveMemberConsentUseCaseSpec extends IntegrationTestSpecification {
     def "사용자는 알림 수신 정책을 수정할 수 있다"() {
         setup:
         def id = initializer.data[2]
-        def expected = MemberNotificationConsentUpdateRequest.builder().isOn(false).build()
+        def expected = MemberNotificationConsentUpdateRequest.builder().notificationConsent(false).build()
 
         when:
         def actual = useCase.execute(expected)

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/member/MemberConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/member/MemberConverter.java
@@ -7,7 +7,6 @@ import com.depromeet.threedays.front.domain.model.member.SaveMemberUseCaseRespon
 import com.depromeet.threedays.front.domain.model.member.Token;
 import com.depromeet.threedays.front.support.converter.MemberInfoJsonConverter;
 import com.depromeet.threedays.front.web.response.SaveMemberResponse;
-
 import java.time.LocalDateTime;
 
 public class MemberConverter {

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/notification/GlobalNotificationConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/notification/GlobalNotificationConverter.java
@@ -21,6 +21,7 @@ public class GlobalNotificationConverter {
 				.notificationId(entity.getId())
 				.contents(entity.getContents())
 				.notificationTime(entity.getNotificationTime())
+				.type(entity.getType())
 				.title(entity.getTitle())
 				.build();
 	}

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/notification/NotificationHistoryConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/notification/NotificationHistoryConverter.java
@@ -3,6 +3,7 @@ package com.depromeet.threedays.front.domain.converter.notification;
 import com.depromeet.threedays.data.entity.client.ClientEntity;
 import com.depromeet.threedays.data.entity.history.NotificationHistoryEntity;
 import com.depromeet.threedays.data.enums.NotificationStatus;
+import com.depromeet.threedays.data.enums.NotificationType;
 import com.depromeet.threedays.front.domain.model.client.Client;
 import com.depromeet.threedays.front.domain.model.notification.HabitNotificationMessage;
 import com.depromeet.threedays.front.domain.model.notification.NotificationMessage;
@@ -16,6 +17,7 @@ public class NotificationHistoryConverter {
 				.notificationId(message.getNotificationId())
 				.contents(message.getContents())
 				.status(status)
+				.type(message.getType())
 				.memberId(client.getMemberId())
 				.build();
 	}
@@ -26,6 +28,7 @@ public class NotificationHistoryConverter {
 				.notificationId(message.getNotificationId())
 				.contents(message.getContent())
 				.status(status)
+				.type(NotificationType.HABIT)
 				.memberId(client.getMemberId())
 				.build();
 	}

--- a/app/src/main/java/com/depromeet/threedays/front/domain/model/notification/NotificationMessage.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/model/notification/NotificationMessage.java
@@ -1,6 +1,8 @@
 package com.depromeet.threedays.front.domain.model.notification;
 
 import java.time.LocalTime;
+
+import com.depromeet.threedays.data.enums.NotificationType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,4 +17,5 @@ public class NotificationMessage {
 	private LocalTime notificationTime;
 	private String contents;
 	private String title;
+	private NotificationType type;
 }

--- a/app/src/main/java/com/depromeet/threedays/front/domain/model/notification/NotificationMessage.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/model/notification/NotificationMessage.java
@@ -1,8 +1,7 @@
 package com.depromeet.threedays.front.domain.model.notification;
 
-import java.time.LocalTime;
-
 import com.depromeet.threedays.data.enums.NotificationType;
+import java.time.LocalTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/data/migration/V1.00.0.3__add_global_notification_type.sql
+++ b/data/migration/V1.00.0.3__add_global_notification_type.sql
@@ -1,0 +1,2 @@
+ALTER TABLE global_notification
+    ADD COLUMN type varchar(255) NOT NULL;

--- a/data/src/main/java/com/depromeet/threedays/data/entity/notification/GlobalNotificationEntity.java
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/notification/GlobalNotificationEntity.java
@@ -1,5 +1,6 @@
 package com.depromeet.threedays.data.entity.notification;
 
+import com.depromeet.threedays.data.enums.NotificationType;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 import javax.persistence.Column;
@@ -10,8 +11,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-
-import com.depromeet.threedays.data.enums.NotificationType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/data/src/main/java/com/depromeet/threedays/data/entity/notification/GlobalNotificationEntity.java
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/notification/GlobalNotificationEntity.java
@@ -10,6 +10,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
+
+import com.depromeet.threedays.data.enums.NotificationType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -41,4 +43,8 @@ public class GlobalNotificationEntity {
 	@Column(name = "day_of_week", nullable = false)
 	@Enumerated(EnumType.STRING)
 	private DayOfWeek dayOfWeek;
+
+	@Column(name = "type")
+	@Enumerated(EnumType.STRING)
+	private NotificationType type;
 }

--- a/data/src/main/java/com/depromeet/threedays/data/enums/NotificationType.java
+++ b/data/src/main/java/com/depromeet/threedays/data/enums/NotificationType.java
@@ -2,5 +2,6 @@ package com.depromeet.threedays.data.enums;
 
 public enum NotificationType {
 	GLOBAL,
-	HABIT
+	HABIT,
+	NOTICE
 }


### PR DESCRIPTION
💁‍♂️ PR 내용
----
notification 발송시 히스토리에 타입을 함께 저장합니다. 

🙏 작업
----
* global notification table에 notification type 추가 (DDL)
* notification type enum에 NOTICE 추가 (현재 HABIT, GLOBAL, NOTICE)
* notification 발송시 history에 타입 저장. habit_notification의 경우HABIT으로 저장 
