### PR TITLE
feat: api response wrapping

### DIFF
--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/notification/SendGlobalNotificationUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/notification/SendGlobalNotificationUseCase.java
@@ -70,8 +70,7 @@ public class SendGlobalNotificationUseCase {
 	}
 
 	private List<Long> getMemberIds() {
-		List<MemberEntity> members = memberRepository.findAllByNotificationConsent(true)
-				.orElse(null);
+		List<MemberEntity> members = memberRepository.findAllByNotificationConsent(true).orElse(null);
 		if (members == null) {
 			return Collections.emptyList();
 		}
@@ -91,8 +90,7 @@ public class SendGlobalNotificationUseCase {
 				.filter(m -> memberIds.contains(m.getMemberId()))
 				.collect(
 						Collectors.groupingBy(
-								it -> counter.getAndIncrement()
-										/ fireBaseProperty.getMulticastMessageSize()))
+								it -> counter.getAndIncrement() / fireBaseProperty.getMulticastMessageSize()))
 				.values();
 	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/notification/SendHabitNotificationUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/notification/SendHabitNotificationUseCase.java
@@ -34,8 +34,7 @@ public class SendHabitNotificationUseCase {
 	private final MessageClient messageClient;
 
 	public List<BatchResponse> execute() {
-		List<HabitNotificationMessage> messages =
-				makeHabitNotificationMessage();
+		List<HabitNotificationMessage> messages = makeHabitNotificationMessage();
 		return sendMessage(messages);
 	}
 
@@ -43,8 +42,7 @@ public class SendHabitNotificationUseCase {
 
 		List<ClientEntity> clientEntities = clientRepository.findAll();
 
-		List<HabitNotificationMessage> messages =
-				getNotificationFilterByNotificationConsent();
+		List<HabitNotificationMessage> messages = getNotificationFilterByNotificationConsent();
 
 		List<List<Client>> groupedClient =
 				new ArrayList<>(
@@ -78,8 +76,7 @@ public class SendHabitNotificationUseCase {
 	}
 
 	private List<Long> getMemberIds() {
-		List<MemberEntity> members = memberRepository.findAllByNotificationConsent(true)
-				.orElse(null);
+		List<MemberEntity> members = memberRepository.findAllByNotificationConsent(true).orElse(null);
 		if (members == null) {
 			return Collections.emptyList();
 		}

--- a/app/src/main/java/com/depromeet/threedays/front/support/ApiResponse.java
+++ b/app/src/main/java/com/depromeet/threedays/front/support/ApiResponse.java
@@ -28,4 +28,12 @@ public class ApiResponse<B> extends ResponseEntity<B> implements Serializable {
 			this.message = message;
 		}
 	}
+
+	@Getter
+	@AllArgsConstructor
+	public static class SuccessBody<D> implements Serializable {
+		private D data;
+		private String message;
+		private String code;
+	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/support/ApiResponseGenerator.java
+++ b/app/src/main/java/com/depromeet/threedays/front/support/ApiResponseGenerator.java
@@ -8,25 +8,29 @@ public class ApiResponseGenerator {
 
 	public static ApiResponse<ApiResponse.SuccessBody<Void>> success(final HttpStatus status) {
 		return new ApiResponse<>(
-				new ApiResponse.SuccessBody<>(null, MessageCode.SUCCESS.getValue(), MessageCode.SUCCESS.getCode()),
+				new ApiResponse.SuccessBody<>(
+						null, MessageCode.SUCCESS.getValue(), MessageCode.SUCCESS.getCode()),
 				status);
 	}
 
 	public static ApiResponse<ApiResponse.SuccessBody<Void>> success(
 			final HttpStatus status, MessageCode code) {
-		return new ApiResponse<>(new ApiResponse.SuccessBody<>(null, code.getValue(), code.getCode()), status);
+		return new ApiResponse<>(
+				new ApiResponse.SuccessBody<>(null, code.getValue(), code.getCode()), status);
 	}
 
 	public static <D> ApiResponse<ApiResponse.SuccessBody<D>> success(
 			final D data, final HttpStatus status) {
 		return new ApiResponse<>(
-				new ApiResponse.SuccessBody<>(data, MessageCode.SUCCESS.getValue(), MessageCode.SUCCESS.getCode()),
+				new ApiResponse.SuccessBody<>(
+						data, MessageCode.SUCCESS.getValue(), MessageCode.SUCCESS.getCode()),
 				status);
 	}
 
 	public static <D> ApiResponse<ApiResponse.SuccessBody<D>> success(
 			final D data, final HttpStatus status, MessageCode code) {
-		return new ApiResponse<>(new ApiResponse.SuccessBody<>(data, code.getValue(), code.getCode()), status);
+		return new ApiResponse<>(
+				new ApiResponse.SuccessBody<>(data, code.getValue(), code.getCode()), status);
 	}
 
 	public static <D> ApiResponse<Page<D>> success(

--- a/app/src/main/java/com/depromeet/threedays/front/support/ApiResponseGenerator.java
+++ b/app/src/main/java/com/depromeet/threedays/front/support/ApiResponseGenerator.java
@@ -6,12 +6,27 @@ import org.springframework.http.HttpStatus;
 @UtilityClass
 public class ApiResponseGenerator {
 
-	public static ApiResponse<Void> success(final HttpStatus status) {
-		return new ApiResponse<>(status);
+	public static ApiResponse<ApiResponse.SuccessBody<Void>> success(final HttpStatus status) {
+		return new ApiResponse<>(
+				new ApiResponse.SuccessBody<>(null, MessageCode.SUCCESS.getValue(), MessageCode.SUCCESS.getCode()),
+				status);
 	}
 
-	public static <D> ApiResponse<D> success(final D data, final HttpStatus status) {
-		return new ApiResponse<>(data, status);
+	public static ApiResponse<ApiResponse.SuccessBody<Void>> success(
+			final HttpStatus status, MessageCode code) {
+		return new ApiResponse<>(new ApiResponse.SuccessBody<>(null, code.getValue(), code.getCode()), status);
+	}
+
+	public static <D> ApiResponse<ApiResponse.SuccessBody<D>> success(
+			final D data, final HttpStatus status) {
+		return new ApiResponse<>(
+				new ApiResponse.SuccessBody<>(data, MessageCode.SUCCESS.getValue(), MessageCode.SUCCESS.getCode()),
+				status);
+	}
+
+	public static <D> ApiResponse<ApiResponse.SuccessBody<D>> success(
+			final D data, final HttpStatus status, MessageCode code) {
+		return new ApiResponse<>(new ApiResponse.SuccessBody<>(data, code.getValue(), code.getCode()), status);
 	}
 
 	public static <D> ApiResponse<Page<D>> success(

--- a/app/src/main/java/com/depromeet/threedays/front/support/MessageCode.java
+++ b/app/src/main/java/com/depromeet/threedays/front/support/MessageCode.java
@@ -12,11 +12,11 @@ public enum MessageCode {
 		this.value = value;
 	}
 
-	public String getCode(){
+	public String getCode() {
 		return this.code;
 	}
 
-	public String getValue(){
+	public String getValue() {
 		return this.value;
 	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/support/MessageCode.java
+++ b/app/src/main/java/com/depromeet/threedays/front/support/MessageCode.java
@@ -1,0 +1,22 @@
+package com.depromeet.threedays.front.support;
+
+public enum MessageCode {
+	SUCCESS("success", "성공"),
+	RESOURCE_DELETED("resource.deleted", "삭제되었습니다."),
+	RESOURCE_CREATED("created", "새로 생성되었습니다.");
+	private final String code;
+	private final String value;
+
+	MessageCode(String code, String value) {
+		this.code = code;
+		this.value = value;
+	}
+
+	public String getCode(){
+		return this.code;
+	}
+
+	public String getValue(){
+		return this.value;
+	}
+}

--- a/app/src/main/java/com/depromeet/threedays/front/support/MessageCode.java
+++ b/app/src/main/java/com/depromeet/threedays/front/support/MessageCode.java
@@ -3,7 +3,7 @@ package com.depromeet.threedays.front.support;
 public enum MessageCode {
 	SUCCESS("success", "성공"),
 	RESOURCE_DELETED("resource.deleted", "삭제되었습니다."),
-	RESOURCE_CREATED("created", "새로 생성되었습니다.");
+	RESOURCE_CREATED("resource.created", "새로 생성되었습니다.");
 	private final String code;
 	private final String value;
 

--- a/app/src/main/java/com/depromeet/threedays/front/web/controller/ClientController.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/controller/ClientController.java
@@ -21,7 +21,8 @@ public class ClientController {
 	private final SaveClientUseCase saveUseCase;
 
 	@PostMapping()
-	public ApiResponse<Client> add(@RequestBody @Valid ClientRequest request) {
-		return ApiResponseGenerator.success(saveUseCase.execute(request), HttpStatus.CREATED);
+	public ApiResponse<ApiResponse.SuccessBody<Client>> add(
+			@RequestBody @Valid ClientRequest request) {
+		return ApiResponseGenerator.success(saveUseCase.execute(request), HttpStatus.OK);
 	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/web/controller/HabitAchievementController.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/controller/HabitAchievementController.java
@@ -38,7 +38,9 @@ public class HabitAchievementController {
 	public ApiResponse<ApiResponse.SuccessBody<HabitResponse>> add(
 			@PathVariable Long habitId, @RequestBody @Valid final SaveHabitAchievementRequest request) {
 		return ApiResponseGenerator.success(
-				HabitResponseConverter.from(saveUseCase.execute(habitId, request)), HttpStatus.CREATED, MessageCode.RESOURCE_CREATED);
+				HabitResponseConverter.from(saveUseCase.execute(habitId, request)),
+				HttpStatus.CREATED,
+				MessageCode.RESOURCE_CREATED);
 	}
 
 	@GetMapping

--- a/app/src/main/java/com/depromeet/threedays/front/web/controller/HabitAchievementController.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/controller/HabitAchievementController.java
@@ -6,6 +6,7 @@ import com.depromeet.threedays.front.domain.usecase.habit.SaveHabitAchievementUs
 import com.depromeet.threedays.front.domain.usecase.habit.SearchHabitAchievementUseCase;
 import com.depromeet.threedays.front.support.ApiResponse;
 import com.depromeet.threedays.front.support.ApiResponseGenerator;
+import com.depromeet.threedays.front.support.MessageCode;
 import com.depromeet.threedays.front.web.request.habit.SaveHabitAchievementRequest;
 import com.depromeet.threedays.front.web.request.habit.SearchHabitAchievementRequest;
 import com.depromeet.threedays.front.web.response.HabitResponse;
@@ -34,20 +35,20 @@ public class HabitAchievementController {
 	private final DeleteHabitAchievementUseCase deleteUseCase;
 
 	@PostMapping
-	public ApiResponse<HabitResponse> add(
+	public ApiResponse<ApiResponse.SuccessBody<HabitResponse>> add(
 			@PathVariable Long habitId, @RequestBody @Valid final SaveHabitAchievementRequest request) {
 		return ApiResponseGenerator.success(
-				HabitResponseConverter.from(saveUseCase.execute(habitId, request)), HttpStatus.CREATED);
+				HabitResponseConverter.from(saveUseCase.execute(habitId, request)), HttpStatus.CREATED, MessageCode.RESOURCE_CREATED);
 	}
 
 	@GetMapping
-	public ApiResponse<List<HabitAchievement>> browse(
+	public ApiResponse<ApiResponse.SuccessBody<List<HabitAchievement>>> browse(
 			@PathVariable Long habitId, final SearchHabitAchievementRequest request) {
 		return ApiResponseGenerator.success(searchUseCase.execute(habitId, request), HttpStatus.OK);
 	}
 
 	@DeleteMapping("/{habitAchievementId}")
-	public ApiResponse<HabitResponse> delete(
+	public ApiResponse<ApiResponse.SuccessBody<HabitResponse>> delete(
 			@PathVariable Long habitId, @PathVariable Long habitAchievementId) {
 		return ApiResponseGenerator.success(
 				HabitResponseConverter.from(deleteUseCase.execute(habitId, habitAchievementId)),

--- a/app/src/main/java/com/depromeet/threedays/front/web/controller/HabitController.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/controller/HabitController.java
@@ -8,6 +8,7 @@ import com.depromeet.threedays.front.domain.usecase.habit.SearchHabitUseCase;
 import com.depromeet.threedays.front.domain.usecase.habit.UpdateHabitUseCase;
 import com.depromeet.threedays.front.support.ApiResponse;
 import com.depromeet.threedays.front.support.ApiResponseGenerator;
+import com.depromeet.threedays.front.support.MessageCode;
 import com.depromeet.threedays.front.web.request.habit.SaveHabitRequest;
 import com.depromeet.threedays.front.web.request.habit.SearchHabitRequest;
 import com.depromeet.threedays.front.web.request.habit.UpdateHabitRequest;
@@ -41,32 +42,34 @@ public class HabitController {
 	private final UpdateHabitUseCase updateUseCase;
 
 	@PostMapping
-	public ApiResponse<HabitResponse> add(@RequestBody @Valid final SaveHabitRequest request) {
+	public ApiResponse<ApiResponse.SuccessBody<HabitResponse>> add(
+			@RequestBody @Valid final SaveHabitRequest request) {
 		return ApiResponseGenerator.success(
-				HabitResponseConverter.from(saveUseCase.execute(request)), HttpStatus.CREATED);
+				HabitResponseConverter.from(saveUseCase.execute(request)), HttpStatus.CREATED, MessageCode.RESOURCE_CREATED);
 	}
 
 	@PutMapping("/{id}")
-	public ApiResponse<HabitResponse> edit(
+	public ApiResponse<ApiResponse.SuccessBody<HabitResponse>> edit(
 			@PathVariable final Long id, @RequestBody @Valid final UpdateHabitRequest request) {
 		return ApiResponseGenerator.success(
 				HabitResponseConverter.from(updateUseCase.execute(id, request)), HttpStatus.OK);
 	}
 
 	@GetMapping
-	public ApiResponse<List<HabitOverview>> browse(final SearchHabitRequest request) {
+	public ApiResponse<ApiResponse.SuccessBody<List<HabitOverview>>> browse(
+			final SearchHabitRequest request) {
 		return ApiResponseGenerator.success(searchUseCase.execute(request), HttpStatus.OK);
 	}
 
 	@GetMapping("/{id}")
-	public ApiResponse<HabitResponse> read(@PathVariable final Long id) {
+	public ApiResponse<ApiResponse.SuccessBody<HabitResponse>> read(@PathVariable final Long id) {
 		return ApiResponseGenerator.success(
 				HabitResponseConverter.from(getUseCase.execute(id)), HttpStatus.OK);
 	}
 
 	@DeleteMapping("/{id}")
-	public ApiResponse<Void> delete(@PathVariable final Long id) {
+	public ApiResponse<ApiResponse.SuccessBody<Void>> delete(@PathVariable final Long id) {
 		deleteUseCase.execute(id);
-		return ApiResponseGenerator.success(HttpStatus.NO_CONTENT);
+		return ApiResponseGenerator.success(HttpStatus.OK, MessageCode.RESOURCE_DELETED);
 	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/web/controller/HabitController.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/controller/HabitController.java
@@ -45,7 +45,9 @@ public class HabitController {
 	public ApiResponse<ApiResponse.SuccessBody<HabitResponse>> add(
 			@RequestBody @Valid final SaveHabitRequest request) {
 		return ApiResponseGenerator.success(
-				HabitResponseConverter.from(saveUseCase.execute(request)), HttpStatus.CREATED, MessageCode.RESOURCE_CREATED);
+				HabitResponseConverter.from(saveUseCase.execute(request)),
+				HttpStatus.CREATED,
+				MessageCode.RESOURCE_CREATED);
 	}
 
 	@PutMapping("/{id}")

--- a/app/src/main/java/com/depromeet/threedays/front/web/controller/MateController.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/controller/MateController.java
@@ -33,7 +33,8 @@ public class MateController {
 	@PostMapping()
 	public ApiResponse<ApiResponse.SuccessBody<Mate>> add(
 			@PathVariable Long habitId, @RequestBody @Valid final SaveMateRequest request) {
-		return ApiResponseGenerator.success(saveUseCase.execute(habitId, request), HttpStatus.CREATED, MessageCode.RESOURCE_CREATED);
+		return ApiResponseGenerator.success(
+				saveUseCase.execute(habitId, request), HttpStatus.CREATED, MessageCode.RESOURCE_CREATED);
 	}
 
 	@DeleteMapping("/{id}")

--- a/app/src/main/java/com/depromeet/threedays/front/web/controller/MateController.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/controller/MateController.java
@@ -6,6 +6,7 @@ import com.depromeet.threedays.front.domain.usecase.mate.GetMateUseCase;
 import com.depromeet.threedays.front.domain.usecase.mate.SaveMateUseCase;
 import com.depromeet.threedays.front.support.ApiResponse;
 import com.depromeet.threedays.front.support.ApiResponseGenerator;
+import com.depromeet.threedays.front.support.MessageCode;
 import com.depromeet.threedays.front.web.request.mate.SaveMateRequest;
 import com.depromeet.threedays.front.web.response.MateResponse;
 import javax.validation.Valid;
@@ -30,19 +31,21 @@ public class MateController {
 	private final GetMateUseCase getUseCase;
 
 	@PostMapping()
-	public ApiResponse<Mate> add(
+	public ApiResponse<ApiResponse.SuccessBody<Mate>> add(
 			@PathVariable Long habitId, @RequestBody @Valid final SaveMateRequest request) {
-		return ApiResponseGenerator.success(saveUseCase.execute(habitId, request), HttpStatus.CREATED);
+		return ApiResponseGenerator.success(saveUseCase.execute(habitId, request), HttpStatus.CREATED, MessageCode.RESOURCE_CREATED);
 	}
 
 	@DeleteMapping("/{id}")
-	public ApiResponse<Void> delete(@PathVariable Long habitId, @PathVariable Long id) {
+	public ApiResponse<ApiResponse.SuccessBody<Void>> delete(
+			@PathVariable Long habitId, @PathVariable Long id) {
 		deleteUseCase.execute(habitId, id);
-		return ApiResponseGenerator.success(HttpStatus.NO_CONTENT);
+		return ApiResponseGenerator.success(HttpStatus.OK, MessageCode.RESOURCE_DELETED);
 	}
 
 	@GetMapping("/{id}")
-	public ApiResponse<MateResponse> read(@PathVariable Long habitId, @PathVariable final Long id) {
+	public ApiResponse<ApiResponse.SuccessBody<MateResponse>> read(
+			@PathVariable Long habitId, @PathVariable final Long id) {
 		return ApiResponseGenerator.success(getUseCase.execute(habitId, id), HttpStatus.OK);
 	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/web/controller/MemberController.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/controller/MemberController.java
@@ -8,6 +8,7 @@ import com.depromeet.threedays.front.domain.usecase.client.DeleteClientUseCase;
 import com.depromeet.threedays.front.domain.usecase.member.*;
 import com.depromeet.threedays.front.support.ApiResponse;
 import com.depromeet.threedays.front.support.ApiResponseGenerator;
+import com.depromeet.threedays.front.support.MessageCode;
 import com.depromeet.threedays.front.web.request.client.DeleteClientRequest;
 import com.depromeet.threedays.front.web.request.member.MemberNameUpdateRequest;
 import com.depromeet.threedays.front.web.request.member.MemberNotificationConsentUpdateRequest;
@@ -36,47 +37,54 @@ public class MemberController {
 	private final GetMemberUseCase getUseCase;
 
 	@PostMapping
-	public ApiResponse<SaveMemberResponse> add(@RequestBody @Valid SignMemberRequest request) {
+	public ApiResponse<ApiResponse.SuccessBody<SaveMemberResponse>> add(
+			@RequestBody @Valid SignMemberRequest request) {
 		SaveMemberUseCaseResponse member = signUseCase.execute(request);
-		HttpStatus status = Boolean.TRUE.equals(member.getIsNew()) ? HttpStatus.CREATED : HttpStatus.OK;
-		return ApiResponseGenerator.success(MemberConverter.to(member), status);
+		if (Boolean.TRUE.equals(member.getIsNew())) {
+			return ApiResponseGenerator.success(
+					MemberConverter.to(member), HttpStatus.CREATED, MessageCode.RESOURCE_CREATED);
+		} else {
+			return ApiResponseGenerator.success(MemberConverter.to(member), HttpStatus.OK);
+		}
 	}
 
 	@PatchMapping("/name")
-	public ApiResponse<Member> updateName(@RequestBody @Valid MemberNameUpdateRequest request) {
+	public ApiResponse<ApiResponse.SuccessBody<Member>> updateName(
+			@RequestBody @Valid MemberNameUpdateRequest request) {
 		return ApiResponseGenerator.success(saveNameUseCase.execute(request), HttpStatus.OK);
 	}
 
 	@PatchMapping("/consents")
-	public ApiResponse<Member> updateConsent(
+	public ApiResponse<ApiResponse.SuccessBody<Member>> updateConsent(
 			@RequestBody @Valid MemberNotificationConsentUpdateRequest request) {
 		return ApiResponseGenerator.success(saveConsentUseCase.execute(request), HttpStatus.OK);
 	}
 
 	@PatchMapping("/resources")
-	public ApiResponse<Member> updateResource(
+	public ApiResponse<ApiResponse.SuccessBody<Member>> updateResource(
 			@RequestBody @Valid MemberResourceUpdateRequest request) {
 		return ApiResponseGenerator.success(saveResourceUseCase.execute(request), HttpStatus.OK);
 	}
 
 	@PostMapping("/tokens")
-	public ApiResponse<Token> refreshToken(@RequestBody Token token) {
+	public ApiResponse<ApiResponse.SuccessBody<Token>> refreshToken(@RequestBody Token token) {
 		return ApiResponseGenerator.success(getTokenUseCase.execute(token), HttpStatus.CREATED);
 	}
 
 	@DeleteMapping
-	public ApiResponse<Void> deleteMember() {
+	public ApiResponse<ApiResponse.SuccessBody<Void>> deleteMember() {
 		deleteUseCase.execute();
-		return ApiResponseGenerator.success(HttpStatus.NO_CONTENT);
+		return ApiResponseGenerator.success(HttpStatus.OK, MessageCode.RESOURCE_DELETED);
 	}
 
 	@GetMapping
-	public ApiResponse<Member> readMember() {
+	public ApiResponse<ApiResponse.SuccessBody<Member>> readMember() {
 		return ApiResponseGenerator.success(getUseCase.execute(), HttpStatus.OK);
 	}
 
 	@PostMapping("/logout")
-	public ApiResponse<Void> deleteClient(@RequestBody @Valid DeleteClientRequest request) {
+	public ApiResponse<ApiResponse.SuccessBody<Void>> deleteClient(
+			@RequestBody @Valid DeleteClientRequest request) {
 		deleteClientUseCase.execute(request);
 		return ApiResponseGenerator.success(HttpStatus.NO_CONTENT);
 	}

--- a/app/src/main/java/com/depromeet/threedays/front/web/controller/NotificationController.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/controller/NotificationController.java
@@ -35,12 +35,12 @@ public class NotificationController {
 	private final SaveNotificationUseCase saveUseCase;
 
 	@GetMapping
-	public ApiResponse<List<NotificationHistory>> browse() {
+	public ApiResponse<ApiResponse.SuccessBody<List<NotificationHistory>>> browse() {
 		return ApiResponseGenerator.success(searchUseCase.execute(), HttpStatus.OK);
 	}
 
 	@PatchMapping("/{id}")
-	public ApiResponse<Void> editStatus(
+	public ApiResponse<ApiResponse.SuccessBody<Void>> editStatus(
 			@PathVariable final Long id,
 			@RequestBody @Valid final EditStatusNotificationRequest request) {
 		saveUseCase.execute(id, request);
@@ -48,18 +48,18 @@ public class NotificationController {
 	}
 
 	@PostMapping("/global")
-	public ApiResponse<List<NotificationBatchResponse>> sendGlobalNotification() {
+	public ApiResponse<ApiResponse.SuccessBody<List<NotificationBatchResponse>>>
+			sendGlobalNotification() {
 		return ApiResponseGenerator.success(globalUseCase.execute(), HttpStatus.OK);
 	}
 
 	@PostMapping("/habit")
-	public ApiResponse<List<BatchResponse>> sendHabitNotification() {
+	public ApiResponse<ApiResponse.SuccessBody<List<BatchResponse>>> sendHabitNotification() {
 		return ApiResponseGenerator.success(habitUseCase.execute(), HttpStatus.OK);
 	}
 
 	@PostMapping("/test")
-	public ApiResponse<Void> test() {
-		System.out.println("test Call");
+	public ApiResponse<ApiResponse.SuccessBody<Void>> test() {
 		return ApiResponseGenerator.success(HttpStatus.OK);
 	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/web/controller/RecordController.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/controller/RecordController.java
@@ -19,7 +19,8 @@ public class RecordController {
 	private final SearchRecordUseCase searchUseCase;
 
 	@GetMapping
-	public ApiResponse<RecordResponse> browse(final SearchRecordRequest request) {
+	public ApiResponse<ApiResponse.SuccessBody<RecordResponse>> browse(
+			final SearchRecordRequest request) {
 		return ApiResponseGenerator.success(searchUseCase.execute(request), HttpStatus.OK);
 	}
 }


### PR DESCRIPTION
💁‍♂️ PR 내용
----
ApiResponse SuccessBody 생성

🙏 작업
----

delete의 경우 헤더를 204로 내리면 바디가 사라짐으로 헤더가 200으로 내려갑니다. 
created의 경우 헤더는 201이며, 별도의 code와 message가 내려갑니다.

📸 스크린샷
----
```
{
    "data": {
        "id": 1,
        "name": "new",
        "certificationSubject": "GOOGLE",
        "notificationConsent": true,
        "resource": {}
    },
    "message": "성공",
    "code": "success"
}
```

```
{
    "data": {
        "id": 1,
        "name": "new",
        "certificationSubject": "GOOGLE",
        "notificationConsent": true,
        "resource": {}
    },
    "message": "새로 생성되었습니다.",
    "code": "resource.created"
}
```

```
{
    "data": null,
    "message": "삭제되었습니다.",
    "code": "resource.deleted"
}
```

🤖 테스트 체크리스트
----
- [x] 체크 완료
- [x] lint 
