### PR TITLE
DEP-228 feat: 생성시각, 수정시각 설정방식 개선

### DIFF
--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/data/habit/FakeHabitAchievementEntity.java
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/data/habit/FakeHabitAchievementEntity.java
@@ -2,20 +2,26 @@ package com.depromeet.threedays.front.data.habit;
 
 import com.depromeet.threedays.data.entity.habit.HabitAchievementEntity;
 import com.depromeet.threedays.front.support.DateCalculator;
+
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public class FakeHabitAchievementEntity {
+    private FakeHabitAchievementEntity() {
+    }
 
-	static HabitAchievementEntity createBy(Long habitId, int index) {
-		return HabitAchievementEntity.builder()
-				.habitId(habitId)
-				.memberId(0L)
-				.achievementDate(LocalDate.now().minusDays(index))
-				.nextAchievementDate(DateCalculator.findNextDate(
-						FakeHabitEntity.dayOfWeeks,
-						LocalDate.now()))
-				.sequence(index + 1)
-				.build();
-	}
+    static HabitAchievementEntity createBy(Long habitId, int index) {
+        return HabitAchievementEntity.builder()
+                .habitId(habitId)
+                .memberId(0L)
+                .sequence(index + 1)
+                .achievementDate(LocalDate.now().minusDays(index))
+                .nextAchievementDate(DateCalculator.findNextDate(
+                        FakeHabitEntity.dayOfWeeks,
+                        LocalDate.now()))
+                .createAt(LocalDateTime.now())
+                .updateAt(LocalDateTime.now())
+                .build();
+    }
 
 }

--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/data/habit/FakeHabitEntity.java
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/data/habit/FakeHabitEntity.java
@@ -2,38 +2,40 @@ package com.depromeet.threedays.front.data.habit;
 
 import com.depromeet.threedays.data.entity.habit.HabitEntity;
 import com.depromeet.threedays.data.enums.HabitStatus;
-import java.time.DayOfWeek;
-import java.util.EnumSet;
 import net.bytebuddy.utility.RandomString;
 
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.util.EnumSet;
+
 public class FakeHabitEntity {
+    static EnumSet<DayOfWeek> dayOfWeeks = EnumSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY,
+            DayOfWeek.SUNDAY);
 
-	static EnumSet<DayOfWeek> dayOfWeeks = EnumSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY,
-			DayOfWeek.SUNDAY);
+    private FakeHabitEntity() {
+    }
 
-	static HabitEntity create() {
-		return HabitEntity.builder()
-				.imojiPath(RandomString.make())
-				.memberId(0L)
-				.title(RandomString.make())
-				.dayOfWeeks(dayOfWeeks)
-				.archiveNumberOfDate(0)
-				.color(RandomString.make())
-				.status(HabitStatus.ACTIVE)
-				.deleted(false)
-				.build();
+    static HabitEntity create() {
+        return from(0L);
+    }
+
+    static HabitEntity create(Long memberId) {
+		return from(memberId);
 	}
-	static HabitEntity create(Long memberId) {
-		return HabitEntity.builder()
-				.imojiPath(RandomString.make())
-				.memberId(memberId)
-				.title(RandomString.make())
-				.dayOfWeeks(dayOfWeeks)
-				.archiveNumberOfDate(0)
-				.color(RandomString.make())
-				.status(HabitStatus.ACTIVE)
-				.deleted(false)
-				.build();
-	}
+
+    private static HabitEntity from(Long memberId) {
+        return HabitEntity.builder()
+                .imojiPath(RandomString.make())
+                .memberId(memberId)
+                .title(RandomString.make())
+                .dayOfWeeks(dayOfWeeks)
+                .archiveNumberOfDate(0)
+                .color(RandomString.make())
+                .status(HabitStatus.ACTIVE)
+                .createAt(LocalDateTime.now())
+                .updateAt(LocalDateTime.now())
+                .deleted(false)
+                .build();
+    }
 
 }

--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/data/mate/FakeMateEntity.java
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/data/mate/FakeMateEntity.java
@@ -2,20 +2,25 @@ package com.depromeet.threedays.front.data.mate;
 
 import com.depromeet.threedays.data.entity.mate.MateEntity;
 import com.depromeet.threedays.data.enums.MateType;
-import java.time.LocalDateTime;
 import net.bytebuddy.utility.RandomString;
 
-public class FakeMateEntity {
+import java.time.LocalDateTime;
 
-	public static MateEntity create(Long habitId) {
-		return MateEntity.builder()
-				.title(RandomString.make())
-				.deleted(false)
-				.createAt(LocalDateTime.now())
-				.memberId(0L)
-				.habitId(habitId)
-				.characterType(MateType.CARROT)
-				.level(3)
-				.build();
-	}
+public class FakeMateEntity {
+    private FakeMateEntity() {
+    }
+
+    public static MateEntity create(Long habitId) {
+        return MateEntity.builder()
+                .memberId(0L)
+                .title(RandomString.make())
+                .habitId(habitId)
+                .level(3)
+                .levelUpAt(LocalDateTime.now())
+                .characterType(MateType.CARROT)
+                .createAt(LocalDateTime.now())
+                .updateAt(LocalDateTime.now())
+                .deleted(false)
+                .build();
+    }
 }

--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/data/member/FakeMemberEntity.java
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/data/member/FakeMemberEntity.java
@@ -1,18 +1,24 @@
-package com.depromeet.threedays.front.data.habit;
+package com.depromeet.threedays.front.data.member;
 
 import com.depromeet.threedays.data.entity.member.MemberEntity;
 import com.depromeet.threedays.data.enums.CertificationSubject;
 import net.bytebuddy.utility.RandomString;
 
+import java.time.LocalDateTime;
+
 public class FakeMemberEntity {
+	private FakeMemberEntity() {
+	}
 
 	public static MemberEntity create() {
 		return MemberEntity.builder()
-				.name(RandomString.make())
 				.certificationId(RandomString.make())
+				.name(RandomString.make())
 				.certificationSubject(CertificationSubject.GOOGLE)
-				.notificationConsent(true)
 				.resource("{\"te\":\"te\"}")
+				.notificationConsent(true)
+				.createAt(LocalDateTime.now())
+				.updateAt(LocalDateTime.now())
 				.build();
 	}
 }

--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/data/member/MemberInitializer.groovy
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/data/member/MemberInitializer.groovy
@@ -3,7 +3,6 @@ package com.depromeet.threedays.front.data.member
 import com.depromeet.threedays.data.entity.habit.HabitEntity
 import com.depromeet.threedays.data.entity.member.MemberEntity
 import com.depromeet.threedays.data.enums.HabitStatus
-import com.depromeet.threedays.front.data.habit.FakeMemberEntity
 import com.depromeet.threedays.front.persistence.repository.habit.HabitRepository
 import com.depromeet.threedays.front.persistence.repository.member.MemberRepository
 import net.bytebuddy.utility.RandomString

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/RewardHistoryConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/RewardHistoryConverter.java
@@ -3,7 +3,6 @@ package com.depromeet.threedays.front.domain.converter;
 import com.depromeet.threedays.data.entity.history.RewardHistoryEntity;
 import com.depromeet.threedays.front.domain.model.RewardHistory;
 import com.depromeet.threedays.front.domain.model.habit.Habit;
-import java.time.LocalDateTime;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -12,8 +11,6 @@ public class RewardHistoryConverter {
 		return RewardHistoryEntity.builder()
 				.habitId(habit.getId())
 				.memberId(habit.getMemberId())
-				.createAt(LocalDateTime.now())
-				.updateAt(LocalDateTime.now())
 				.build();
 	}
 

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/client/ClientConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/client/ClientConverter.java
@@ -3,7 +3,6 @@ package com.depromeet.threedays.front.domain.converter.client;
 import com.depromeet.threedays.data.entity.client.ClientEntity;
 import com.depromeet.threedays.front.domain.model.client.Client;
 import com.depromeet.threedays.front.web.request.client.ClientRequest;
-import java.time.LocalDateTime;
 
 public class ClientConverter {
 
@@ -33,7 +32,6 @@ public class ClientConverter {
 				.memberId(memberId)
 				.fcmToken(request.getFcmToken())
 				.identificationKey(request.getIdentificationKey())
-				.updateAt(LocalDateTime.now())
 				.build();
 	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/habit/HabitAchievementConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/habit/HabitAchievementConverter.java
@@ -5,7 +5,6 @@ import com.depromeet.threedays.front.domain.model.habit.Habit;
 import com.depromeet.threedays.front.domain.model.habit.HabitAchievement;
 import com.depromeet.threedays.front.web.request.habit.SaveHabitAchievementRequest;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -34,7 +33,6 @@ public class HabitAchievementConverter {
 				.habitId(habit.getId())
 				.memberId(habit.getMemberId())
 				.achievementDate(request.getAchievementDate())
-				.updateAt(LocalDateTime.now())
 				.nextAchievementDate(nextAchievementDate)
 				.sequence(sequence)
 				.build();

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/habit/HabitConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/habit/HabitConverter.java
@@ -10,7 +10,6 @@ import com.depromeet.threedays.front.domain.model.mate.Mate;
 import com.depromeet.threedays.front.domain.model.notification.Notification;
 import com.depromeet.threedays.front.web.request.habit.SaveHabitRequest;
 import com.depromeet.threedays.front.web.request.habit.UpdateHabitRequest;
-import java.time.LocalDateTime;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -88,7 +87,6 @@ public class HabitConverter {
 				.archiveNumberOfDate(data.getArchiveNumberOfDate())
 				.status(data.getStatus())
 				.deleted(data.getDeleted())
-				.updateAt(LocalDateTime.now())
 				.build();
 	}
 
@@ -210,8 +208,6 @@ public class HabitConverter {
 				.archiveNumberOfDate(source.getArchiveNumberOfDate())
 				.color(request.getColor())
 				.status(source.getStatus())
-				.createAt(source.getCreateAt())
-				.updateAt(LocalDateTime.now())
 				.deleted(source.getDeleted())
 				.build();
 	}

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/mate/MateConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/mate/MateConverter.java
@@ -4,7 +4,6 @@ import com.depromeet.threedays.data.entity.mate.MateEntity;
 import com.depromeet.threedays.front.config.security.AuditorHolder;
 import com.depromeet.threedays.front.domain.model.mate.Mate;
 import com.depromeet.threedays.front.web.request.mate.SaveMateRequest;
-import java.time.LocalDateTime;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -40,7 +39,6 @@ public class MateConverter {
 				.memberId(data.getMemberId())
 				.habitId(data.getHabitId())
 				.levelUpAt(data.getLevelUpAt())
-				.updateAt(LocalDateTime.now())
 				.build();
 	}
 

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/member/MemberConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/member/MemberConverter.java
@@ -7,7 +7,6 @@ import com.depromeet.threedays.front.domain.model.member.SaveMemberUseCaseRespon
 import com.depromeet.threedays.front.domain.model.member.Token;
 import com.depromeet.threedays.front.support.converter.MemberInfoJsonConverter;
 import com.depromeet.threedays.front.web.response.SaveMemberResponse;
-import java.time.LocalDateTime;
 
 public class MemberConverter {
 
@@ -42,8 +41,6 @@ public class MemberConverter {
 				.certificationId(command.getCertificationId())
 				.certificationSubject(command.getCertificationSubject())
 				.resource(command.getResource())
-				.createAt(LocalDateTime.now())
-				.updateAt(LocalDateTime.now())
 				.notificationConsent(command.getNotificationConsent())
 				.build();
 	}

--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/notification/HabitNotificationConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/notification/HabitNotificationConverter.java
@@ -5,7 +5,6 @@ import com.depromeet.threedays.front.config.security.AuditorHolder;
 import com.depromeet.threedays.front.domain.model.notification.HabitNotificationMessage;
 import com.depromeet.threedays.front.domain.model.notification.Notification;
 import java.time.DayOfWeek;
-import java.time.LocalDateTime;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -17,7 +16,6 @@ public class HabitNotificationConverter {
 				.memberId(AuditorHolder.get())
 				.contents(data.getContents())
 				.notificationTime(data.getNotificationTime())
-				.updateAt(LocalDateTime.now())
 				.dayOfWeek(dayOfWeek)
 				.build();
 	}

--- a/app/src/main/java/com/depromeet/threedays/front/persistence/JpaConfig.java
+++ b/app/src/main/java/com/depromeet/threedays/front/persistence/JpaConfig.java
@@ -1,8 +1,0 @@
-package com.depromeet.threedays.front.persistence;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
-@EnableJpaAuditing
-@Configuration
-public class JpaConfig {}

--- a/data/migration/V1.00.0.5__add_audit.sql
+++ b/data/migration/V1.00.0.5__add_audit.sql
@@ -1,0 +1,4 @@
+ALTER TABLE global_notification
+    ADD COLUMN create_at datetime(6) NOT NULL;
+ALTER TABLE global_notification
+    ADD COLUMN update_at datetime(6);

--- a/data/src/main/java/com/depromeet/threedays/data/JpaDataSourceConfig.java
+++ b/data/src/main/java/com/depromeet/threedays/data/JpaDataSourceConfig.java
@@ -13,6 +13,7 @@ import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 import org.springframework.orm.jpa.JpaTransactionManager;
@@ -21,6 +22,7 @@ import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+@EnableJpaAuditing
 @Configuration
 @EnableTransactionManagement
 @EnableJpaRepositories(

--- a/data/src/main/java/com/depromeet/threedays/data/JpaDataSourceConfig.java
+++ b/data/src/main/java/com/depromeet/threedays/data/JpaDataSourceConfig.java
@@ -22,8 +22,8 @@ import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
-@EnableJpaAuditing
 @Configuration
+@EnableJpaAuditing
 @EnableTransactionManagement
 @EnableJpaRepositories(
 		basePackages = JpaDataSourceConfig.BASE_PACKAGE,

--- a/data/src/main/java/com/depromeet/threedays/data/entity/client/ClientEntity.java
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/client/ClientEntity.java
@@ -1,17 +1,15 @@
 package com.depromeet.threedays.data.entity.client;
 
 import java.time.LocalDateTime;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -19,6 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Builder(toBuilder = true)
 @Table(name = "client")
+@EntityListeners(AuditingEntityListener.class)
 public class ClientEntity {
 
 	@Id
@@ -36,10 +35,11 @@ public class ClientEntity {
 	private String identificationKey;
 
 	@Column(nullable = false, updatable = false)
-	@Builder.Default
-	private LocalDateTime createAt = LocalDateTime.now();
+	@CreatedDate
+	private LocalDateTime createAt;
 
 	@Column(nullable = false)
+	@LastModifiedDate
 	private LocalDateTime updateAt;
 
 	public void updateFcmToken(String fcmToken) {

--- a/data/src/main/java/com/depromeet/threedays/data/entity/habit/HabitAchievementEntity.java
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/habit/HabitAchievementEntity.java
@@ -2,17 +2,15 @@ package com.depromeet.threedays.data.entity.habit;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Builder(toBuilder = true)
 @Table(name = "habit_achievement")
+@EntityListeners(AuditingEntityListener.class)
 public class HabitAchievementEntity {
 
 	@Id
@@ -43,9 +42,10 @@ public class HabitAchievementEntity {
 	private LocalDate nextAchievementDate;
 
 	@Column(nullable = false, updatable = false)
-	@Builder.Default
-	private LocalDateTime createAt = LocalDateTime.now();
+	@CreatedDate
+	private LocalDateTime createAt;
 
 	@Column(nullable = false)
+	@LastModifiedDate
 	private LocalDateTime updateAt;
 }

--- a/data/src/main/java/com/depromeet/threedays/data/entity/habit/HabitEntity.java
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/habit/HabitEntity.java
@@ -5,20 +5,15 @@ import com.depromeet.threedays.data.enums.HabitStatus;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.util.EnumSet;
-import javax.persistence.Column;
-import javax.persistence.Convert;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,6 +21,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Builder(toBuilder = true)
 @Table(name = "habit")
+@EntityListeners(AuditingEntityListener.class)
 public class HabitEntity {
 
 	@Id
@@ -56,10 +52,11 @@ public class HabitEntity {
 	private HabitStatus status = HabitStatus.ACTIVE;
 
 	@Column(nullable = false, updatable = false)
-	@Builder.Default
-	private LocalDateTime createAt = LocalDateTime.now();
+	@CreatedDate
+	private LocalDateTime createAt;
 
 	@Column(nullable = false)
+	@LastModifiedDate
 	private LocalDateTime updateAt;
 
 	@Column(nullable = false)

--- a/data/src/main/java/com/depromeet/threedays/data/entity/history/NotificationHistoryEntity.java
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/history/NotificationHistoryEntity.java
@@ -3,19 +3,15 @@ package com.depromeet.threedays.data.entity.history;
 import com.depromeet.threedays.data.enums.NotificationStatus;
 import com.depromeet.threedays.data.enums.NotificationType;
 import java.time.LocalDateTime;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -23,6 +19,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Builder(toBuilder = true)
 @Table(name = "notification_history")
+@EntityListeners(AuditingEntityListener.class)
 public class NotificationHistoryEntity {
 
 	@Id
@@ -40,10 +37,11 @@ public class NotificationHistoryEntity {
 	private String contents;
 
 	@Column(nullable = false, updatable = false)
-	@Builder.Default
-	private LocalDateTime createAt = LocalDateTime.now();
+	@CreatedDate
+	private LocalDateTime createAt;
 
 	@Column(nullable = false)
+	@LastModifiedDate
 	private LocalDateTime updateAt;
 
 	@Column(name = "status", length = 100, nullable = false)

--- a/data/src/main/java/com/depromeet/threedays/data/entity/history/RewardHistoryEntity.java
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/history/RewardHistoryEntity.java
@@ -1,17 +1,15 @@
 package com.depromeet.threedays.data.entity.history;
 
 import java.time.LocalDateTime;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -19,6 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Builder(toBuilder = true)
 @Table(name = "reward_history")
+@EntityListeners(AuditingEntityListener.class)
 public class RewardHistoryEntity {
 
 	@Id
@@ -33,9 +32,10 @@ public class RewardHistoryEntity {
 	private Long memberId;
 
 	@Column(nullable = false, updatable = false)
-	@Builder.Default
-	private LocalDateTime createAt = LocalDateTime.now();
+	@CreatedDate
+	private LocalDateTime createAt;
 
 	@Column(nullable = false)
+	@LastModifiedDate
 	private LocalDateTime updateAt;
 }

--- a/data/src/main/java/com/depromeet/threedays/data/entity/mate/MateEntity.java
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/mate/MateEntity.java
@@ -2,19 +2,15 @@ package com.depromeet.threedays.data.entity.mate;
 
 import com.depromeet.threedays.data.enums.MateType;
 import java.time.LocalDateTime;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Builder(toBuilder = true)
 @Table(name = "mate")
+@EntityListeners(AuditingEntityListener.class)
 public class MateEntity {
 
 	@Id
@@ -48,10 +45,11 @@ public class MateEntity {
 	private MateType characterType;
 
 	@Column(nullable = false, updatable = false)
-	@Builder.Default
-	private LocalDateTime createAt = LocalDateTime.now();
+	@CreatedDate
+	private LocalDateTime createAt;
 
 	@Column(nullable = false)
+	@LastModifiedDate
 	private LocalDateTime updateAt;
 
 	@Column(nullable = false)

--- a/data/src/main/java/com/depromeet/threedays/data/entity/member/MemberEntity.java
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/member/MemberEntity.java
@@ -3,19 +3,15 @@ package com.depromeet.threedays.data.entity.member;
 import com.depromeet.threedays.data.enums.CertificationSubject;
 import java.io.Serializable;
 import java.time.LocalDateTime;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -23,6 +19,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Builder(toBuilder = true)
 @Table(name = "member")
+@EntityListeners(AuditingEntityListener.class)
 public class MemberEntity implements Serializable {
 
 	@Id
@@ -44,24 +41,22 @@ public class MemberEntity implements Serializable {
 	@Column private Boolean notificationConsent;
 
 	@Column(nullable = false, updatable = false)
-	@Builder.Default
-	private LocalDateTime createAt = LocalDateTime.now();
+	@CreatedDate
+	private LocalDateTime createAt;
 
 	@Column(nullable = false)
+	@LastModifiedDate
 	private LocalDateTime updateAt;
 
 	public void updateName(String name) {
 		this.name = name;
-		this.updateAt = LocalDateTime.now();
 	}
 
 	public void updateNotificationConsent(Boolean consent) {
 		this.notificationConsent = consent;
-		this.updateAt = LocalDateTime.now();
 	}
 
 	public void updateResource(String resource) {
 		this.resource = resource;
-		this.updateAt = LocalDateTime.now();
 	}
 }

--- a/data/src/main/java/com/depromeet/threedays/data/entity/notification/GlobalNotificationEntity.java
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/notification/GlobalNotificationEntity.java
@@ -2,20 +2,17 @@ package com.depromeet.threedays.data.entity.notification;
 
 import com.depromeet.threedays.data.enums.NotificationType;
 import java.time.DayOfWeek;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -23,6 +20,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Builder(toBuilder = true)
 @Table(name = "global_notification")
+@EntityListeners(AuditingEntityListener.class)
 public class GlobalNotificationEntity {
 
 	@Id
@@ -46,4 +44,12 @@ public class GlobalNotificationEntity {
 	@Column(name = "type")
 	@Enumerated(EnumType.STRING)
 	private NotificationType type;
+
+	@Column(nullable = false, updatable = false)
+	@CreatedDate
+	private LocalDateTime createAt;
+
+	@Column(nullable = false)
+	@LastModifiedDate
+	private LocalDateTime updateAt;
 }

--- a/data/src/main/java/com/depromeet/threedays/data/entity/notification/HabitNotificationEntity.java
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/notification/HabitNotificationEntity.java
@@ -3,14 +3,7 @@ package com.depromeet.threedays.data.entity.notification;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,6 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -25,6 +19,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 @Entity
 @Builder(toBuilder = true)
 @Table(name = "habit_notification")
+@EntityListeners(AuditingEntityListener.class)
 public class HabitNotificationEntity {
 
 	@Id

--- a/data/src/main/java/com/depromeet/threedays/data/entity/notification/HabitNotificationEntity.java
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/notification/HabitNotificationEntity.java
@@ -16,6 +16,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -47,9 +49,10 @@ public class HabitNotificationEntity {
 	private DayOfWeek dayOfWeek;
 
 	@Column(nullable = false, updatable = false)
-	@Builder.Default
-	private LocalDateTime createAt = LocalDateTime.now();
+	@CreatedDate
+	private LocalDateTime createAt;
 
 	@Column(nullable = false)
+	@LastModifiedDate
 	private LocalDateTime updateAt;
 }


### PR DESCRIPTION
💁‍♂️ PR 내용
----
- 생성, 수정시각 설정 방법 개선 (entity listener)
- GlobalNotificationEntity 에 createAt, updateAt 컬럼 추가
- Entity 생성 코드 개선


🙏 작업
----

**[AS-IS]**
- createAt, updateAt 을 코드에서 일일이 설정함

**[TO-BE]**
- AuditingEntityListener 적용해서 자동으로 값 넣어주도록 변경


