### PR TITLE
Dep-221: add mate bubble

### DIFF
--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/mate/MateConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/mate/MateConverter.java
@@ -3,6 +3,7 @@ package com.depromeet.threedays.front.domain.converter.mate;
 import com.depromeet.threedays.data.entity.mate.MateEntity;
 import com.depromeet.threedays.front.config.security.AuditorHolder;
 import com.depromeet.threedays.front.domain.model.mate.Mate;
+import com.depromeet.threedays.front.support.MateBubble;
 import com.depromeet.threedays.front.web.request.mate.SaveMateRequest;
 import java.time.LocalDateTime;
 import lombok.experimental.UtilityClass;
@@ -24,6 +25,7 @@ public class MateConverter {
 				.characterType(entity.getCharacterType())
 				.title(entity.getTitle())
 				.levelUpAt(entity.getLevelUpAt())
+				.bubble(MateBubble.randomBubble().getBubble())
 				.build();
 	}
 

--- a/app/src/main/java/com/depromeet/threedays/front/domain/model/mate/Mate.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/model/mate/Mate.java
@@ -22,4 +22,5 @@ public class Mate implements Serializable {
 	private Integer level;
 	private LocalDateTime levelUpAt;
 	private MateType characterType;
+	private String bubble;
 }

--- a/app/src/main/java/com/depromeet/threedays/front/support/MateBubble.java
+++ b/app/src/main/java/com/depromeet/threedays/front/support/MateBubble.java
@@ -1,0 +1,23 @@
+package com.depromeet.threedays.front.support;
+
+import java.util.Random;
+
+public enum MateBubble {
+	DUMMY("오늘도 열심히 하쟈");
+	private final String bubble;
+
+	MateBubble(String bubble) {
+		this.bubble = bubble;
+	}
+
+	public String getBubble() {
+		return this.bubble;
+	}
+
+	private static final Random PRNG = new Random();
+
+	public static MateBubble randomBubble() {
+		MateBubble[] mateBubbles = values();
+		return mateBubbles[PRNG.nextInt(mateBubbles.length)];
+	}
+}

--- a/app/src/main/java/com/depromeet/threedays/front/web/response/MateResponse.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/response/MateResponse.java
@@ -28,4 +28,5 @@ public class MateResponse {
 	private LocalDateTime levelUpAt;
 	private MateType characterType;
 	private List<Integer> levelUpSection;
+	private String bubble;
 }

--- a/app/src/main/java/com/depromeet/threedays/front/web/response/converter/MateResponseConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/response/converter/MateResponseConverter.java
@@ -1,6 +1,7 @@
 package com.depromeet.threedays.front.web.response.converter;
 
 import com.depromeet.threedays.front.domain.model.mate.Mate;
+import com.depromeet.threedays.front.support.MateBubble;
 import com.depromeet.threedays.front.web.response.MateResponse;
 import lombok.experimental.UtilityClass;
 
@@ -21,6 +22,7 @@ public class MateResponseConverter {
 				.characterType(mate.getCharacterType())
 				.title(mate.getTitle())
 				.levelUpAt(mate.getLevelUpAt())
+				.bubble(MateBubble.randomBubble().getBubble())
 				.build();
 	}
 }

--- a/app/src/main/resources/static/openapi3.yml
+++ b/app/src/main/resources/static/openapi3.yml
@@ -266,7 +266,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Mate'
+                $ref: '#/components/schemas/MateResponse'
         '500':
           description: INTERNAL SERVER ERROR
           content:
@@ -1110,6 +1110,38 @@ components:
         bubble:
           type: string
           example: "오늘도 열심히 하쟈"
+        levelUpAt:
+          type: string
+          format: date-time
+          example: "2022-11-30 21:40:18.668458"
+        createAt:
+          type: string
+          format: date-time
+          example: "2022-11-30 21:40:18.668458"
+    MateResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        memberId:
+          type: integer
+          example: 1
+        habitId:
+          type: integer
+          example: 1
+        title:
+          type: string
+          example: "짝꿍이"
+        level:
+          type: integer
+          example: 1
+        characterType:
+          enum: [ "WHIP", "CARROT" ]
+          example: "WHIP"
+        bubble:
+          type: string
+          example: "오늘도 열심히 하쟈"
         reward:
           type: integer
           example: 6
@@ -1121,7 +1153,7 @@ components:
                 type: string
                 format: date-time
                 example: "2022-11-30 21:40:18.668458"
-        levelUpSectioin:
+        levelUpSection:
           type: array
           example: [ 1,4,8,14,22 ]
         levelUpAt:

--- a/app/src/main/resources/static/openapi3.yml
+++ b/app/src/main/resources/static/openapi3.yml
@@ -1107,6 +1107,9 @@ components:
         characterType:
           enum: [ "WHIP", "CARROT" ]
           example: "WHIP"
+        bubble:
+          type: string
+          example: "오늘도 열심히 하쟈"
         reward:
           type: integer
           example: 6


### PR DESCRIPTION
💁‍♂️ PR 내용
----
짝꿍 조회시 말풍선 `bubble` 필드를 추가했습니다. 
다음 api의 response에 말풍선 `bubble` 필드를 추가했습니다.
GET /api/v1/habits/{habitId}/mates
DELETE /api/v1/habits/{habitId}/mates/{id}
GET /api/v1/habits/{habitId}/mates/{id}

🙏 작업
----
* Response에 bubble 추가
* api와 api spec 동기화


🙈 PR 참고 사항
----
현재 예시 말풍선 대사를 enum으로 작성해뒀는데, 생각해보니 딱히 넣을 상수값이 없더라구요.. 
디자이너 분들이 넘겨주신 파일에서 line으로 읽어들여 랜덤하게 출력하도록 변경하는 편이 나을까 싶습니다. 해당 부분 의견 부탁드립니다. 


📸 스크린샷
----
![image](https://user-images.githubusercontent.com/45715824/208704657-43619aa4-e4e0-41b6-8ded-dd808c9472b2.png)

🤖 테스트 체크리스트
----
- [x] 체크 완료
