### PR TITLE
DEP-290 fix : response format 수정

### DIFF
--- a/app/src/main/java/com/depromeet/threedays/front/config/security/SecurityConfig.java
+++ b/app/src/main/java/com/depromeet/threedays/front/config/security/SecurityConfig.java
@@ -62,8 +62,8 @@ public class SecurityConfig {
 				generateAuthenticationFilter(), AbstractPreAuthenticatedProcessingFilter.class);
 
 		http.exceptionHandling()
-			.authenticationEntryPoint(authenticationEntryPoint)
-			.accessDeniedHandler(accessDeniedHandler);
+				.authenticationEntryPoint(authenticationEntryPoint)
+				.accessDeniedHandler(accessDeniedHandler);
 
 		http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 		return http.build();

--- a/app/src/main/java/com/depromeet/threedays/front/config/security/SecurityConfig.java
+++ b/app/src/main/java/com/depromeet/threedays/front/config/security/SecurityConfig.java
@@ -60,8 +60,12 @@ public class SecurityConfig {
 
 		http.addFilterAt(
 				generateAuthenticationFilter(), AbstractPreAuthenticatedProcessingFilter.class);
-		http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
+		http.exceptionHandling()
+			.authenticationEntryPoint(authenticationEntryPoint)
+			.accessDeniedHandler(accessDeniedHandler);
+
+		http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 		return http.build();
 	}
 

--- a/app/src/main/java/com/depromeet/threedays/front/web/controller/ApiControllerExceptionHandler.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/controller/ApiControllerExceptionHandler.java
@@ -13,6 +13,7 @@ import org.hibernate.TypeMismatchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
@@ -87,9 +88,9 @@ public class ApiControllerExceptionHandler {
 		return ApiResponseGenerator.fail(FAIL_CODE, FORBIDDEN_MESSAGE, HttpStatus.FORBIDDEN);
 	}
 
-	@ExceptionHandler({AuthenticationException.class})
+	@ExceptionHandler({InsufficientAuthenticationException.class, AuthenticationException.class})
 	public ApiResponse<ApiResponse.FailureBody> handle(
-			final AuthenticationException ex, final WebRequest request) {
+			final Exception ex, final WebRequest request) {
 		this.writeLog(ex, request);
 		return ApiResponseGenerator.fail(FAIL_CODE, UNAUTHORIZED_MESSAGE, HttpStatus.UNAUTHORIZED);
 	}

--- a/app/src/main/java/com/depromeet/threedays/front/web/controller/ApiControllerExceptionHandler.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/controller/ApiControllerExceptionHandler.java
@@ -34,121 +34,119 @@ public class ApiControllerExceptionHandler {
 	private static final String LOG_MESSAGE_FORMAT = "{} '{}' - {}";
 	private static final String UNCAUGHT_LOG_MESSAGE = "??";
 
-	private static final String BAD_REQUEST_CODE = "400";
+	private static final String FAIL_CODE = "fail";
+
 	private static final String BAD_REQUEST_MESSAGE = "잘못된 요청입니다.";
 
-	private static final String FORBIDDEN_CODE = "403";
 	private static final String FORBIDDEN_MESSAGE = "접근 권한이 없습니다.";
 
-	private static final String NOT_FOUND_CODE = "404";
 	private static final String NOT_FOUND_MESSAGE = "요청과 일치하는 결과를 찾을 수 없습니다.";
 
-	private static final String SERVER_ERROR_CODE = "500";
 	private static final String SERVER_ERROR_MESSAGE = "알 수 없는 오류가 발생하였습니다.";
 
 	@ExceptionHandler(IllegalArgumentException.class)
 	public final ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final IllegalArgumentException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(PolicyViolationException.class)
 	public final ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final PolicyViolationException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler({MethodArgumentTypeMismatchException.class, TypeMismatchException.class})
 	public final ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final TypeMismatchException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(ServletRequestBindingException.class)
 	public final ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final ServletRequestBindingException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler({BindException.class, MethodArgumentNotValidException.class})
 	public final ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final BindException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(ConstraintViolationException.class)
 	public final ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final ConstraintViolationException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
 	public ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final HttpRequestMethodNotSupportedException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(HttpMediaTypeNotSupportedException.class)
 	public ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final HttpMediaTypeNotSupportedException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(HttpMediaTypeNotAcceptableException.class)
 	public ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final HttpMediaTypeNotAcceptableException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(HttpMessageNotReadableException.class)
 	public ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final HttpMessageNotReadableException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(MissingServletRequestPartException.class)
 	public ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final MissingServletRequestPartException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler({ResourceNotFoundException.class, NoHandlerFoundException.class})
 	public ApiResponse<ApiResponse.FailureBody> handleNotFound(
 			final Exception ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(NOT_FOUND_CODE, NOT_FOUND_MESSAGE, HttpStatus.NOT_FOUND);
+		return ApiResponseGenerator.fail(FAIL_CODE, NOT_FOUND_MESSAGE, HttpStatus.NOT_FOUND);
 	}
 
 	@ExceptionHandler(AccessDeniedException.class)
 	public ApiResponse<ApiResponse.FailureBody> handleForbidden(
 			final AccessDeniedException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(FORBIDDEN_CODE, FORBIDDEN_MESSAGE, HttpStatus.FORBIDDEN);
+		return ApiResponseGenerator.fail(FAIL_CODE, FORBIDDEN_MESSAGE, HttpStatus.FORBIDDEN);
 	}
 
 	@ExceptionHandler(InsufficientAuthenticationException.class)
 	public ApiResponse<ApiResponse.FailureBody> handleForbidden(
 			final InsufficientAuthenticationException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(FORBIDDEN_CODE, FORBIDDEN_MESSAGE, HttpStatus.FORBIDDEN);
+		return ApiResponseGenerator.fail(FAIL_CODE, FORBIDDEN_MESSAGE, HttpStatus.FORBIDDEN);
 	}
 
 	@ExceptionHandler({JsonParsingException.class})
 	public ApiResponse<ApiResponse.FailureBody> handleJson(
 			final JsonParsingException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(FORBIDDEN_CODE, FORBIDDEN_MESSAGE, HttpStatus.FORBIDDEN);
+		return ApiResponseGenerator.fail(FAIL_CODE, FORBIDDEN_MESSAGE, HttpStatus.FORBIDDEN);
 	}
 
 	@ExceptionHandler(Exception.class)
@@ -156,7 +154,7 @@ public class ApiControllerExceptionHandler {
 			final Exception ex, final WebRequest request) {
 		this.writeLog(ex, request);
 		return ApiResponseGenerator.fail(
-				SERVER_ERROR_CODE, SERVER_ERROR_MESSAGE, HttpStatus.INTERNAL_SERVER_ERROR);
+				FAIL_CODE, SERVER_ERROR_MESSAGE, HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 
 	private <E extends Exception> void writeLog(final E ex, final WebRequest webRequest) {

--- a/app/src/main/java/com/depromeet/threedays/front/web/controller/ApiControllerExceptionHandler.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/controller/ApiControllerExceptionHandler.java
@@ -51,72 +51,22 @@ public class ApiControllerExceptionHandler {
 		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
-	@ExceptionHandler(PolicyViolationException.class)
+	@ExceptionHandler({
+		PolicyViolationException.class,
+		MethodArgumentTypeMismatchException.class,
+		TypeMismatchException.class,
+		ServletRequestBindingException.class,
+		BindException.class,
+		MethodArgumentNotValidException.class,
+		ConstraintViolationException.class,
+		HttpRequestMethodNotSupportedException.class,
+		HttpMediaTypeNotSupportedException.class,
+		HttpMediaTypeNotAcceptableException.class,
+		HttpMessageNotReadableException.class,
+		MissingServletRequestPartException.class
+	})
 	public final ApiResponse<ApiResponse.FailureBody> handleBadRequest(
-			final PolicyViolationException ex, final WebRequest request) {
-		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
-	}
-
-	@ExceptionHandler({MethodArgumentTypeMismatchException.class, TypeMismatchException.class})
-	public final ApiResponse<ApiResponse.FailureBody> handleBadRequest(
-			final TypeMismatchException ex, final WebRequest request) {
-		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
-	}
-
-	@ExceptionHandler(ServletRequestBindingException.class)
-	public final ApiResponse<ApiResponse.FailureBody> handleBadRequest(
-			final ServletRequestBindingException ex, final WebRequest request) {
-		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
-	}
-
-	@ExceptionHandler({BindException.class, MethodArgumentNotValidException.class})
-	public final ApiResponse<ApiResponse.FailureBody> handleBadRequest(
-			final BindException ex, final WebRequest request) {
-		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
-	}
-
-	@ExceptionHandler(ConstraintViolationException.class)
-	public final ApiResponse<ApiResponse.FailureBody> handleBadRequest(
-			final ConstraintViolationException ex, final WebRequest request) {
-		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
-	}
-
-	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-	public ApiResponse<ApiResponse.FailureBody> handleBadRequest(
-			final HttpRequestMethodNotSupportedException ex, final WebRequest request) {
-		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
-	}
-
-	@ExceptionHandler(HttpMediaTypeNotSupportedException.class)
-	public ApiResponse<ApiResponse.FailureBody> handleBadRequest(
-			final HttpMediaTypeNotSupportedException ex, final WebRequest request) {
-		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
-	}
-
-	@ExceptionHandler(HttpMediaTypeNotAcceptableException.class)
-	public ApiResponse<ApiResponse.FailureBody> handleBadRequest(
-			final HttpMediaTypeNotAcceptableException ex, final WebRequest request) {
-		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
-	}
-
-	@ExceptionHandler(HttpMessageNotReadableException.class)
-	public ApiResponse<ApiResponse.FailureBody> handleBadRequest(
-			final HttpMessageNotReadableException ex, final WebRequest request) {
-		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
-	}
-
-	@ExceptionHandler(MissingServletRequestPartException.class)
-	public ApiResponse<ApiResponse.FailureBody> handleBadRequest(
-			final MissingServletRequestPartException ex, final WebRequest request) {
+			final Exception ex, final WebRequest request) {
 		this.writeLog(ex, request);
 		return ApiResponseGenerator.fail(FAIL_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
@@ -128,16 +78,9 @@ public class ApiControllerExceptionHandler {
 		return ApiResponseGenerator.fail(FAIL_CODE, NOT_FOUND_MESSAGE, HttpStatus.NOT_FOUND);
 	}
 
-	@ExceptionHandler(AccessDeniedException.class)
+	@ExceptionHandler({AccessDeniedException.class, InsufficientAuthenticationException.class})
 	public ApiResponse<ApiResponse.FailureBody> handleForbidden(
-			final AccessDeniedException ex, final WebRequest request) {
-		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(FAIL_CODE, FORBIDDEN_MESSAGE, HttpStatus.FORBIDDEN);
-	}
-
-	@ExceptionHandler(InsufficientAuthenticationException.class)
-	public ApiResponse<ApiResponse.FailureBody> handleForbidden(
-			final InsufficientAuthenticationException ex, final WebRequest request) {
+			final Exception ex, final WebRequest request) {
 		this.writeLog(ex, request);
 		return ApiResponseGenerator.fail(FAIL_CODE, FORBIDDEN_MESSAGE, HttpStatus.FORBIDDEN);
 	}

--- a/app/src/main/java/com/depromeet/threedays/front/web/controller/ApiControllerExceptionHandler.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/controller/ApiControllerExceptionHandler.java
@@ -89,8 +89,7 @@ public class ApiControllerExceptionHandler {
 	}
 
 	@ExceptionHandler({InsufficientAuthenticationException.class, AuthenticationException.class})
-	public ApiResponse<ApiResponse.FailureBody> handle(
-			final Exception ex, final WebRequest request) {
+	public ApiResponse<ApiResponse.FailureBody> handle(final Exception ex, final WebRequest request) {
 		this.writeLog(ex, request);
 		return ApiResponseGenerator.fail(FAIL_CODE, UNAUTHORIZED_MESSAGE, HttpStatus.UNAUTHORIZED);
 	}

--- a/app/src/main/java/com/depromeet/threedays/front/web/controller/ApiControllerExceptionHandler.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/controller/ApiControllerExceptionHandler.java
@@ -5,6 +5,7 @@ import com.depromeet.threedays.front.exception.PolicyViolationException;
 import com.depromeet.threedays.front.exception.ResourceNotFoundException;
 import com.depromeet.threedays.front.support.ApiResponse;
 import com.depromeet.threedays.front.support.ApiResponseGenerator;
+import javax.naming.AuthenticationException;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
@@ -12,7 +13,6 @@ import org.hibernate.TypeMismatchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
@@ -39,6 +39,8 @@ public class ApiControllerExceptionHandler {
 	private static final String BAD_REQUEST_MESSAGE = "잘못된 요청입니다.";
 
 	private static final String FORBIDDEN_MESSAGE = "접근 권한이 없습니다.";
+
+	private static final String UNAUTHORIZED_MESSAGE = "인증이 필요합니다.";
 
 	private static final String NOT_FOUND_MESSAGE = "요청과 일치하는 결과를 찾을 수 없습니다.";
 
@@ -78,11 +80,18 @@ public class ApiControllerExceptionHandler {
 		return ApiResponseGenerator.fail(FAIL_CODE, NOT_FOUND_MESSAGE, HttpStatus.NOT_FOUND);
 	}
 
-	@ExceptionHandler({AccessDeniedException.class, InsufficientAuthenticationException.class})
+	@ExceptionHandler({AccessDeniedException.class})
 	public ApiResponse<ApiResponse.FailureBody> handleForbidden(
-			final Exception ex, final WebRequest request) {
+			final AccessDeniedException ex, final WebRequest request) {
 		this.writeLog(ex, request);
 		return ApiResponseGenerator.fail(FAIL_CODE, FORBIDDEN_MESSAGE, HttpStatus.FORBIDDEN);
+	}
+
+	@ExceptionHandler({AuthenticationException.class})
+	public ApiResponse<ApiResponse.FailureBody> handle(
+			final AuthenticationException ex, final WebRequest request) {
+		this.writeLog(ex, request);
+		return ApiResponseGenerator.fail(FAIL_CODE, UNAUTHORIZED_MESSAGE, HttpStatus.UNAUTHORIZED);
 	}
 
 	@ExceptionHandler({JsonParsingException.class})

--- a/app/src/main/java/com/depromeet/threedays/front/web/controller/ApiControllerExceptionHandler.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/controller/ApiControllerExceptionHandler.java
@@ -32,108 +32,123 @@ public class ApiControllerExceptionHandler {
 
 	private static final String LOG_MESSAGE_FORMAT = "{} '{}' - {}";
 	private static final String UNCAUGHT_LOG_MESSAGE = "??";
+
+	private static final String BAD_REQUEST_CODE = "400";
 	private static final String BAD_REQUEST_MESSAGE = "잘못된 요청입니다.";
+
+	private static final String FORBIDDEN_CODE = "403";
+	private static final String FORBIDDEN_MESSAGE = "접근 권한이 없습니다.";
+
+	private static final String NOT_FOUND_CODE = "404";
+	private static final String NOT_FOUND_MESSAGE = "요청과 일치하는 결과를 찾을 수 없습니다.";
+
+	private static final String SERVER_ERROR_CODE = "500";
+	private static final String SERVER_ERROR_MESSAGE = "알 수 없는 오류가 발생하였습니다.";
 
 	@ExceptionHandler(IllegalArgumentException.class)
 	public final ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final IllegalArgumentException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(PolicyViolationException.class)
 	public final ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final PolicyViolationException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler({MethodArgumentTypeMismatchException.class, TypeMismatchException.class})
 	public final ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final TypeMismatchException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(ServletRequestBindingException.class)
 	public final ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final ServletRequestBindingException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler({BindException.class, MethodArgumentNotValidException.class})
 	public final ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final BindException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(ConstraintViolationException.class)
 	public final ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final ConstraintViolationException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
 	public ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final HttpRequestMethodNotSupportedException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(HttpMediaTypeNotSupportedException.class)
 	public ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final HttpMediaTypeNotSupportedException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(HttpMediaTypeNotAcceptableException.class)
 	public ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final HttpMediaTypeNotAcceptableException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(HttpMessageNotReadableException.class)
 	public ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final HttpMessageNotReadableException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(MissingServletRequestPartException.class)
 	public ApiResponse<ApiResponse.FailureBody> handleBadRequest(
 			final MissingServletRequestPartException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
+		return ApiResponseGenerator.fail(BAD_REQUEST_CODE, BAD_REQUEST_MESSAGE, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler({ResourceNotFoundException.class, NoHandlerFoundException.class})
-	public ApiResponse<Void> handleNotFound(final Exception ex, final WebRequest request) {
+	public ApiResponse<ApiResponse.FailureBody> handleNotFound(
+			final Exception ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(HttpStatus.NOT_FOUND);
+		return ApiResponseGenerator.fail(NOT_FOUND_CODE, NOT_FOUND_MESSAGE, HttpStatus.NOT_FOUND);
 	}
 
 	@ExceptionHandler({AccessDeniedException.class})
-	public ApiResponse<Void> handleForbidden(
+	public ApiResponse<ApiResponse.FailureBody> handleForbidden(
 			final AccessDeniedException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(HttpStatus.FORBIDDEN);
+		return ApiResponseGenerator.fail(FORBIDDEN_CODE, FORBIDDEN_MESSAGE, HttpStatus.FORBIDDEN);
 	}
 
 	@ExceptionHandler({JsonParsingException.class})
-	public ApiResponse<Void> handleJson(final JsonParsingException ex, final WebRequest request) {
+	public ApiResponse<ApiResponse.FailureBody> handleJson(
+			final JsonParsingException ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(HttpStatus.FORBIDDEN);
+		return ApiResponseGenerator.fail(FORBIDDEN_CODE, FORBIDDEN_MESSAGE, HttpStatus.FORBIDDEN);
 	}
 
 	@ExceptionHandler(Exception.class)
-	public ApiResponse<Void> handleInternalServerError(final Exception ex, final WebRequest request) {
+	public ApiResponse<ApiResponse.FailureBody> handleInternalServerError(
+			final Exception ex, final WebRequest request) {
 		this.writeLog(ex, request);
-		return ApiResponseGenerator.fail(HttpStatus.INTERNAL_SERVER_ERROR);
+		return ApiResponseGenerator.fail(
+				SERVER_ERROR_CODE, SERVER_ERROR_MESSAGE, HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 
 	private <E extends Exception> void writeLog(final E ex, final WebRequest webRequest) {

--- a/app/src/main/java/com/depromeet/threedays/front/web/controller/ApiControllerExceptionHandler.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/controller/ApiControllerExceptionHandler.java
@@ -12,6 +12,7 @@ import org.hibernate.TypeMismatchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
@@ -129,9 +130,16 @@ public class ApiControllerExceptionHandler {
 		return ApiResponseGenerator.fail(NOT_FOUND_CODE, NOT_FOUND_MESSAGE, HttpStatus.NOT_FOUND);
 	}
 
-	@ExceptionHandler({AccessDeniedException.class})
+	@ExceptionHandler(AccessDeniedException.class)
 	public ApiResponse<ApiResponse.FailureBody> handleForbidden(
 			final AccessDeniedException ex, final WebRequest request) {
+		this.writeLog(ex, request);
+		return ApiResponseGenerator.fail(FORBIDDEN_CODE, FORBIDDEN_MESSAGE, HttpStatus.FORBIDDEN);
+	}
+
+	@ExceptionHandler(InsufficientAuthenticationException.class)
+	public ApiResponse<ApiResponse.FailureBody> handleForbidden(
+			final InsufficientAuthenticationException ex, final WebRequest request) {
 		this.writeLog(ex, request);
 		return ApiResponseGenerator.fail(FORBIDDEN_CODE, FORBIDDEN_MESSAGE, HttpStatus.FORBIDDEN);
 	}


### PR DESCRIPTION
### 💁‍♂️ PR 내용
403 예외가 톰캣 예외 메시지로 응답되는 문제 해결

### 🙏 작업
[AS-IS]
- prod 환경에서 security filter 에외 발생시 핸들링 안됨
- JWT 토큰 없이 요청보냈을떄 발생 하는 예외(InsufficientAuthenticationException) 핸들링 메서드 누락

[TO-BE]
- prod 환경 security filter단 예외를 ExceptionHandler 가 핸들링 할 수 있도록 변경
- InsufficientAuthenticationException 핸들링 메서드 추가

### 📸 스크린샷
테스트는 SecurityConfig의 prod 환경 설정을 local로 변경하고 테스트를 진행하였습니다.
![스크린샷 2022-12-26 오전 11 50 50](https://user-images.githubusercontent.com/78407939/209494154-2e031d72-497a-42d4-9d73-52d56a2d547f.png)
