### PR TITLE
DEP-306 fix : jwt access, refresh token 유효기간 수정

### DIFF
--- a/app/src/main/java/com/depromeet/threedays/front/support/TokenGenerator.java
+++ b/app/src/main/java/com/depromeet/threedays/front/support/TokenGenerator.java
@@ -16,8 +16,11 @@ public class TokenGenerator {
 	@Value("${security.jwt.token.secretkey}")
 	private String secretKey;
 
-	@Value("${security.jwt.token.validtime}")
-	private Long tokenValidTime;
+	@Value("${security.jwt.token.validtime.access}")
+	private Long accessTokenValidTime;
+
+	@Value("${security.jwt.token.validtime.refresh}")
+	private Long refreshTokenValidTime;
 
 	private static final String MEMBER_ID_CLAIM_KEY = "memberId";
 
@@ -28,7 +31,7 @@ public class TokenGenerator {
 				.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
 				.claim(MEMBER_ID_CLAIM_KEY, memberId)
 				.setIssuedAt(now)
-				.setExpiration(new Date(now.getTime() + tokenValidTime))
+				.setExpiration(new Date(now.getTime() + accessTokenValidTime))
 				.signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
 				.compact();
 	}
@@ -40,7 +43,7 @@ public class TokenGenerator {
 				.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
 				.claim(MEMBER_ID_CLAIM_KEY, memberId)
 				.setIssuedAt(now)
-				.setExpiration(new Date(now.getTime() + tokenValidTime * 10))
+				.setExpiration(new Date(now.getTime() + refreshTokenValidTime))
 				.signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
 				.compact();
 	}

--- a/app/src/main/resources/application-local.yml
+++ b/app/src/main/resources/application-local.yml
@@ -13,7 +13,9 @@ spring:
 security:
   jwt:
     token:
-      validtime: 72000000
+      validtime:
+        access: 31557600000
+        refresh: 31557600000
       secretkey: localkeyyyyyyyyyyyyyyyyyyyyyyyyy
 
 google:

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -39,8 +39,11 @@ server:
 security:
   jwt:
     token:
-      validtime: ${TOKEN_VALIDTIME}
       secretkey: ${TOKEN_SECRETKEY}
+      validtime:
+        access: 21600000
+        refresh: 2073600000
+
 
 google:
   host: https://www.googleapis.com/oauth2


### PR DESCRIPTION
💁‍♂️ PR 내용
----
- accesstoken과 refreshtoken의 유효기간을 수정하였습니다.
- 토큰 유효기간이 GitHub Secrets가 아닌 yml로 관리되어지도록 수정하였습니다.

🙏 작업
----

**[AS-IS]**

[local]
- accesstoken = 72000000
- refreshtoken = accesstoken * 10

[prod]
- accesstoken = GitHub Secrets로 인한 확인 어려움
- refreshtoken = accesstoken * 10

**[TO-BE]**

[local]
- accesstoken = 31557600000 (1년)
- refreshtoken = 31557600000 (1년)

[prod]
- accesstoken = 21600000(6시간)
- refreshtoken = 2073600000(24일)

📸 스크린샷
----
[local]

- local accesstoken 유효기간 확인
<img width="581" alt="스크린샷 2022-12-28 오전 11 31 46" src="https://user-images.githubusercontent.com/78407939/209748605-515cef67-af73-4039-90ca-c1f84a36e8ce.png">



[prod]

생성일 : 2022년 12월 28일, 11시 21~22분

- prod accesstoken 유효기간 확인
<img width="581" alt="스크린샷 2022-12-28 오전 11 23 08" src="https://user-images.githubusercontent.com/78407939/209748579-eb628575-123c-4536-bb76-c9ee031b65ac.png">


- prod refreshtoken 유효기간 확인
<img width="581" alt="스크린샷 2022-12-28 오전 11 22 40" src="https://user-images.githubusercontent.com/78407939/209748540-f148c23b-12bb-46d3-9b76-f54d5e2d6937.png">
