### PR TITLE
DEP-361 fix : not null 필드에 대한 응답 값 수정

### DIFF
--- a/app/src/main/java/com/depromeet/threedays/front/domain/converter/habit/HabitConverter.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/converter/habit/HabitConverter.java
@@ -12,8 +12,6 @@ import com.depromeet.threedays.front.web.request.habit.SaveHabitRequest;
 import com.depromeet.threedays.front.web.request.habit.UpdateHabitRequest;
 import lombok.experimental.UtilityClass;
 
-import java.time.LocalDateTime;
-
 @UtilityClass
 public class HabitConverter {
 
@@ -223,17 +221,17 @@ public class HabitConverter {
 		}
 
 		return HabitEntity.builder()
-						  .id(source.getId())
-						  .memberId(source.getMemberId())
-						  .title(request.getTitle())
-						  .imojiPath(request.getImojiPath())
-						  .dayOfWeeks(request.getDayOfWeeks())
-						  .archiveNumberOfDate(source.getArchiveNumberOfDate())
-						  .color(request.getColor())
-						  .status(source.getStatus())
-						  .deleted(source.getDeleted())
-						  .createAt(source.getCreateAt())
-						  .updateAt(source.getArchiveAt())
-						  .build();
+				.id(source.getId())
+				.memberId(source.getMemberId())
+				.title(request.getTitle())
+				.imojiPath(request.getImojiPath())
+				.dayOfWeeks(request.getDayOfWeeks())
+				.archiveNumberOfDate(source.getArchiveNumberOfDate())
+				.color(request.getColor())
+				.status(source.getStatus())
+				.deleted(source.getDeleted())
+				.createAt(source.getCreateAt())
+				.updateAt(source.getArchiveAt())
+				.build();
 	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/DeleteHabitAchievementUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/DeleteHabitAchievementUseCase.java
@@ -37,7 +37,8 @@ public class DeleteHabitAchievementUseCase {
 		Habit habit = HabitConverter.from(habitEntity, this.delete(target));
 
 		return HabitConverter.from(habit, rewardHistoryRepository.countByHabitId(habitId)).toBuilder()
-				.totalAchievementCount(repository.countByHabitId(habitId)).build();
+				.totalAchievementCount(repository.countByHabitId(habitId))
+				.build();
 	}
 
 	private HabitAchievement delete(final HabitAchievement target) {

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitAchievementUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitAchievementUseCase.java
@@ -54,7 +54,11 @@ public class SaveHabitAchievementUseCase {
 						.map(MateConverter::from)
 						.orElse(null);
 
-		final Habit habit = HabitConverter.from(source).toBuilder().totalAchievementCount(repository.countByHabitId(habitId)).mate(mate).build();
+		final Habit habit =
+				HabitConverter.from(source).toBuilder()
+						.totalAchievementCount(repository.countByHabitId(habitId))
+						.mate(mate)
+						.build();
 
 		if (lastHabitAchievement == null) {
 			return HabitConverter.from(

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/UpdateHabitUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/UpdateHabitUseCase.java
@@ -40,16 +40,20 @@ public class UpdateHabitUseCase {
 						.orElseThrow(ResourceNotFoundException::new);
 
 		Long totalAchievementCount = habitAchievementRepository.countByHabitId(habitId);
-		HabitAchievement habitAchievement = habitAchievementRepository
-				.findFirstByHabitIdOrderByAchievementDateDesc(habitId)
-				.map(HabitAchievementConverter::from)
-				.orElse(null);
+		HabitAchievement habitAchievement =
+				habitAchievementRepository
+						.findFirstByHabitIdOrderByAchievementDateDesc(habitId)
+						.map(HabitAchievementConverter::from)
+						.orElse(null);
 
 		updateAssociation(habit, request.getNotification(), request.getDayOfWeeks());
 
 		return HabitConverter.from(
-				repository.save(HabitConverter.to(habit, request)), request.getNotification()).toBuilder()
-				.totalAchievementCount(totalAchievementCount).habitAchievement(habitAchievement).build();
+						repository.save(HabitConverter.to(habit, request)), request.getNotification())
+				.toBuilder()
+				.totalAchievementCount(totalAchievementCount)
+				.habitAchievement(habitAchievement)
+				.build();
 	}
 
 	private void updateAssociation(


### PR DESCRIPTION
💁‍♂️ PR 내용
----
`HabitResponse`를 응답 객체로 사용하는 api들에 대해 not null 필드에 정상 값이 매핑 되어지도록 수정하였습니다.

🙏 작업
----
HabitAchievementController
- add()
- delete()

HabitController
- edit()

위 api 들에 대해 수정을 진행하였습니다.

📸 스크린샷
----
- 습관 달성
<img width="976" alt="습관 달성" src="https://user-images.githubusercontent.com/78407939/211153987-37b6ca7d-3e68-41e8-bb48-1b6b56ca391c.png">

- 습관 취소
<img width="976" alt="습관 취소" src="https://user-images.githubusercontent.com/78407939/211153995-24bd6e26-4df1-4c1e-bc27-86d804906259.png">

- 습관 수정
<img width="976" alt="습관 수정" src="https://user-images.githubusercontent.com/78407939/211154005-45ebd6e7-7e3b-4a00-b7af-f9aafca8ffad.png">


