### PR TITLE
DEP-383 fix: 회원 조회 실패시 401 예외 발생

### DIFF
--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/habit/DeleteHabitUseCaseSpec.groovy
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/habit/DeleteHabitUseCaseSpec.groovy
@@ -1,14 +1,19 @@
 package com.depromeet.threedays.front.domain.usecase.habit
 
+import com.depromeet.threedays.data.entity.member.MemberEntity
 import com.depromeet.threedays.data.enums.HabitStatus
 import com.depromeet.threedays.data.enums.MateStatus
+import com.depromeet.threedays.data.enums.MemberStatus
 import com.depromeet.threedays.front.IntegrationTestSpecification
 import com.depromeet.threedays.front.data.habit.HabitAchievementDataInitializer
 import com.depromeet.threedays.front.data.habit.HabitDataInitializer
 import com.depromeet.threedays.front.data.mate.MateDataInitializer
 import com.depromeet.threedays.front.persistence.repository.habit.HabitRepository
 import com.depromeet.threedays.front.persistence.repository.mate.MateRepository
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository
+import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 import spock.lang.Subject
 
 class DeleteHabitUseCaseSpec extends IntegrationTestSpecification {
@@ -32,8 +37,16 @@ class DeleteHabitUseCaseSpec extends IntegrationTestSpecification {
     @Autowired
     private MateRepository mateRepository
 
+    @MockBean
+    private MemberRepository memberRepository
+
     def setup() {
         habitDataInitializer.initialize()
+        Mockito.when(
+                memberRepository.findByIdAndStatus(Mockito.any(Long.class), Mockito.any(MemberStatus.class))
+        ).thenReturn(
+                Optional.of(MemberEntity.builder().build())
+        )
     }
 
     def "사용자가 짝꿍과 연결된 습관에 삭제를 요청한 경우, 습관과 짝꿍이 보관함으로 이동된다."() {

--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/habit/GetHabitUseCaseSpec.groovy
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/habit/GetHabitUseCaseSpec.groovy
@@ -1,8 +1,13 @@
 package com.depromeet.threedays.front.domain.usecase.habit
 
+import com.depromeet.threedays.data.entity.member.MemberEntity
+import com.depromeet.threedays.data.enums.MemberStatus
 import com.depromeet.threedays.front.IntegrationTestSpecification
 import com.depromeet.threedays.front.data.habit.HabitDataInitializer
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository
+import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 import spock.lang.Subject
 
 class GetHabitUseCaseSpec extends IntegrationTestSpecification {
@@ -14,8 +19,16 @@ class GetHabitUseCaseSpec extends IntegrationTestSpecification {
     @Autowired
     private HabitDataInitializer dataInitializer
 
+    @MockBean
+    private MemberRepository memberRepository
+
     def setup() {
         dataInitializer.initialize()
+        Mockito.when(
+                memberRepository.findByIdAndStatus(Mockito.any(Long.class), Mockito.any(MemberStatus.class))
+        ).thenReturn(
+                Optional.of(MemberEntity.builder().build())
+        )
     }
 
     def "사용자는 자신의 습관 상세를 조회할 수 있다"() {

--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitUseCaseSpec.groovy
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitUseCaseSpec.groovy
@@ -1,10 +1,15 @@
 package com.depromeet.threedays.front.domain.usecase.habit
 
+import com.depromeet.threedays.data.entity.member.MemberEntity
+import com.depromeet.threedays.data.enums.MemberStatus
 import com.depromeet.threedays.front.IntegrationTestSpecification
 import com.depromeet.threedays.front.domain.model.notification.Notification
 import com.depromeet.threedays.front.exception.PolicyViolationException
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository
 import com.depromeet.threedays.front.web.request.habit.SaveHabitRequest
+import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 import spock.lang.Subject
 
 import java.time.DayOfWeek
@@ -16,7 +21,15 @@ class SaveHabitUseCaseSpec extends IntegrationTestSpecification {
     @Autowired
     private SaveHabitUseCase saveUseCase
 
+    @MockBean
+    private MemberRepository memberRepository
+
     def setup() {
+        Mockito.when(
+                memberRepository.findByIdAndStatus(Mockito.any(Long.class), Mockito.any(MemberStatus.class))
+        ).thenReturn(
+                Optional.of(MemberEntity.builder().build())
+        )
     }
 
     def "사용자는 정해진 명세에 맞춰 습관을 생성할 수 있다"() {

--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/habit/SearchHabitUseCaseSpec.groovy
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/habit/SearchHabitUseCaseSpec.groovy
@@ -2,16 +2,21 @@ package com.depromeet.threedays.front.domain.usecase.habit
 
 import com.depromeet.threedays.data.entity.habit.HabitEntity
 import com.depromeet.threedays.data.entity.mate.MateEntity
+import com.depromeet.threedays.data.entity.member.MemberEntity
 import com.depromeet.threedays.data.enums.HabitStatus
 import com.depromeet.threedays.data.enums.MateStatus
 import com.depromeet.threedays.data.enums.MateType
+import com.depromeet.threedays.data.enums.MemberStatus
 import com.depromeet.threedays.front.IntegrationTestSpecification
 import com.depromeet.threedays.front.data.habit.HabitDataInitializer
 import com.depromeet.threedays.front.persistence.repository.habit.HabitRepository
 import com.depromeet.threedays.front.persistence.repository.mate.MateRepository
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository
 import com.depromeet.threedays.front.web.request.habit.SearchHabitRequest
 import net.bytebuddy.utility.RandomString
+import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 import spock.lang.Subject
 
 import java.time.DayOfWeek
@@ -32,8 +37,16 @@ class SearchHabitUseCaseSpec extends IntegrationTestSpecification {
     @Autowired
     private MateRepository mateRepository
 
+    @MockBean
+    private MemberRepository memberRepository
+
     def setup() {
         dataInitializer.initialize()
+        Mockito.when(
+                memberRepository.findByIdAndStatus(Mockito.any(Long.class), Mockito.any(MemberStatus.class))
+        ).thenReturn(
+                Optional.of(MemberEntity.builder().build())
+        )
     }
 
     def "사용자는 자신의 습관 목록을 조회할 수 있다."() {

--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/habit/UpdateHabitUseCaseSpec.groovy
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/habit/UpdateHabitUseCaseSpec.groovy
@@ -1,12 +1,17 @@
 package com.depromeet.threedays.front.domain.usecase.habit
 
+import com.depromeet.threedays.data.entity.member.MemberEntity
+import com.depromeet.threedays.data.enums.MemberStatus
 import com.depromeet.threedays.front.IntegrationTestSpecification
 import com.depromeet.threedays.front.data.habit.HabitDataInitializer
 import com.depromeet.threedays.front.data.habit.HabitNotificationDataInitializer
 import com.depromeet.threedays.front.domain.model.notification.Notification
 import com.depromeet.threedays.front.exception.PolicyViolationException
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository
 import com.depromeet.threedays.front.web.request.habit.UpdateHabitRequest
+import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 import spock.lang.Subject
 
 import java.time.DayOfWeek
@@ -24,8 +29,16 @@ class UpdateHabitUseCaseSpec extends IntegrationTestSpecification {
     @Autowired
     private HabitNotificationDataInitializer notificationDataInitializer
 
+    @MockBean
+    private MemberRepository memberRepository
+
     def setup() {
         dataInitializer.initialize()
+        Mockito.when(
+                memberRepository.findByIdAndStatus(Mockito.any(Long.class), Mockito.any(MemberStatus.class))
+        ).thenReturn(
+                Optional.of(MemberEntity.builder().build())
+        )
     }
 
     def "사용자는 정해진 명세에 맞춰 습관 정보를 갱신할 수 있다"() {

--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/habit/achievement/DeleteHabitAchievementUseCaseSpec.groovy
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/habit/achievement/DeleteHabitAchievementUseCaseSpec.groovy
@@ -1,11 +1,16 @@
 package com.depromeet.threedays.front.domain.usecase.habit.achievement
 
+import com.depromeet.threedays.data.entity.member.MemberEntity
+import com.depromeet.threedays.data.enums.MemberStatus
 import com.depromeet.threedays.front.IntegrationTestSpecification
 import com.depromeet.threedays.front.data.habit.HabitAchievementDataInitializer
 import com.depromeet.threedays.front.data.habit.HabitDataInitializer
 import com.depromeet.threedays.front.domain.usecase.habit.DeleteHabitAchievementUseCase
 import com.depromeet.threedays.front.exception.PolicyViolationException
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository
+import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 import spock.lang.Subject
 
 class DeleteHabitAchievementUseCaseSpec extends IntegrationTestSpecification {
@@ -20,9 +25,17 @@ class DeleteHabitAchievementUseCaseSpec extends IntegrationTestSpecification {
     @Autowired
     private HabitAchievementDataInitializer dataInitializer
 
+    @MockBean
+    private MemberRepository memberRepository
+
     def setup() {
         habitDataInitializer.initialize()
         dataInitializer.initialize(habitDataInitializer.data.first().id)
+        Mockito.when(
+                memberRepository.findByIdAndStatus(Mockito.any(Long.class), Mockito.any(MemberStatus.class))
+        ).thenReturn(
+                Optional.of(MemberEntity.builder().build())
+        )
     }
 
     def "사용자는 오늘의 습관 달성 여부를 취소할 수 있다"() {

--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/habit/achievement/SaveHabitAchievementUseCaseSpec.groovy
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/habit/achievement/SaveHabitAchievementUseCaseSpec.groovy
@@ -1,13 +1,18 @@
 package com.depromeet.threedays.front.domain.usecase.habit.achievement
 
 import com.depromeet.threedays.data.entity.habit.HabitAchievementEntity
+import com.depromeet.threedays.data.entity.member.MemberEntity
+import com.depromeet.threedays.data.enums.MemberStatus
 import com.depromeet.threedays.front.IntegrationTestSpecification
 import com.depromeet.threedays.front.data.habit.HabitAchievementDataInitializer
 import com.depromeet.threedays.front.data.habit.HabitDataInitializer
 import com.depromeet.threedays.front.domain.usecase.habit.SaveHabitAchievementUseCase
 import com.depromeet.threedays.front.exception.PolicyViolationException
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository
 import com.depromeet.threedays.front.web.request.habit.SaveHabitAchievementRequest
+import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 import spock.lang.Subject
 
 import java.time.LocalDate
@@ -24,9 +29,17 @@ class SaveHabitAchievementUseCaseSpec extends IntegrationTestSpecification {
     @Autowired
     private HabitAchievementDataInitializer dataInitializer
 
+    @MockBean
+    private MemberRepository memberRepository
+
     def setup() {
         habitDataInitializer.initialize()
         dataInitializer.initialize(habitDataInitializer.data.first().id)
+        Mockito.when(
+                memberRepository.findByIdAndStatus(Mockito.any(Long.class), Mockito.any(MemberStatus.class))
+        ).thenReturn(
+                Optional.of(MemberEntity.builder().build())
+        )
     }
 
     def "사용자는 오늘의 습관 달성 여부를 체크할 수 있다"() {

--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/habit/achievement/SearchHabitAchievementUseCaseSpec.groovy
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/habit/achievement/SearchHabitAchievementUseCaseSpec.groovy
@@ -1,12 +1,17 @@
 package com.depromeet.threedays.front.domain.usecase.habit.achievement
 
+import com.depromeet.threedays.data.entity.member.MemberEntity
+import com.depromeet.threedays.data.enums.MemberStatus
 import com.depromeet.threedays.front.IntegrationTestSpecification
 import com.depromeet.threedays.front.data.habit.HabitAchievementDataInitializer
 import com.depromeet.threedays.front.data.habit.HabitDataInitializer
 import com.depromeet.threedays.front.domain.model.DatePeriod
 import com.depromeet.threedays.front.domain.usecase.habit.SearchHabitAchievementUseCase
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository
 import com.depromeet.threedays.front.web.request.habit.SearchHabitAchievementRequest
+import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 import spock.lang.Subject
 
 import java.time.LocalDate
@@ -23,9 +28,17 @@ class SearchHabitAchievementUseCaseSpec extends IntegrationTestSpecification {
     @Autowired
     HabitAchievementDataInitializer dataInitializer
 
+    @MockBean
+    private MemberRepository memberRepository
+
     def setup() {
         habitDataInitializer.initialize()
         dataInitializer.initialize(habitDataInitializer.data.first().id)
+        Mockito.when(
+                memberRepository.findByIdAndStatus(Mockito.any(Long.class), Mockito.any(MemberStatus.class))
+        ).thenReturn(
+                Optional.of(MemberEntity.builder().build())
+        )
     }
 
     def "사용자는 자신의 전체 습관 성취 기록을 조회할 수 있다"() {

--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/mate/DeleteMateUseCaseSpec.groovy
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/mate/DeleteMateUseCaseSpec.groovy
@@ -1,10 +1,15 @@
 package com.depromeet.threedays.front.domain.usecase.mate
 
+import com.depromeet.threedays.data.entity.member.MemberEntity
 import com.depromeet.threedays.data.enums.MateStatus
+import com.depromeet.threedays.data.enums.MemberStatus
 import com.depromeet.threedays.front.IntegrationTestSpecification
 import com.depromeet.threedays.front.data.habit.HabitDataInitializer
 import com.depromeet.threedays.front.persistence.repository.mate.MateRepository
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository
+import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 import spock.lang.Subject
 
 class DeleteMateUseCaseSpec extends IntegrationTestSpecification {
@@ -19,8 +24,16 @@ class DeleteMateUseCaseSpec extends IntegrationTestSpecification {
     @Autowired
     private HabitDataInitializer habitDataInitializer
 
+    @MockBean
+    private MemberRepository memberRepository
+
     def setup() {
         habitDataInitializer.initialize()
+        Mockito.when(
+                memberRepository.findByIdAndStatus(Mockito.any(Long.class), Mockito.any(MemberStatus.class))
+        ).thenReturn(
+                Optional.of(MemberEntity.builder().build())
+        )
     }
 
     def "사용자는 짝꿍을 삭제할 수 있다"() {

--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/mate/GetMateCheckUseCaseSpec.groovy
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/mate/GetMateCheckUseCaseSpec.groovy
@@ -1,8 +1,13 @@
 package com.depromeet.threedays.front.domain.usecase.mate
 
+import com.depromeet.threedays.data.entity.member.MemberEntity
+import com.depromeet.threedays.data.enums.MemberStatus
 import com.depromeet.threedays.front.IntegrationTestSpecification
 import com.depromeet.threedays.front.data.habit.HabitDataInitializer
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository
+import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 import spock.lang.Subject
 
 class GetMateCheckUseCaseSpec extends IntegrationTestSpecification {
@@ -13,6 +18,17 @@ class GetMateCheckUseCaseSpec extends IntegrationTestSpecification {
 
     @Autowired
     private HabitDataInitializer habitDataInitializer
+
+    @MockBean
+    private MemberRepository memberRepository
+
+    def setup() {
+        Mockito.when(
+                memberRepository.findByIdAndStatus(Mockito.any(Long.class), Mockito.any(MemberStatus.class))
+        ).thenReturn(
+                Optional.of(MemberEntity.builder().build())
+        )
+    }
 
     def "사용자는 짝꿍이 있을 경우 짝꿍 정보를 볼 수 있다"() {
         given:

--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/mate/GetMateUseCaseSpec.groovy
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/mate/GetMateUseCaseSpec.groovy
@@ -1,8 +1,13 @@
 package com.depromeet.threedays.front.domain.usecase.mate
 
+import com.depromeet.threedays.data.entity.member.MemberEntity
+import com.depromeet.threedays.data.enums.MemberStatus
 import com.depromeet.threedays.front.IntegrationTestSpecification
 import com.depromeet.threedays.front.data.habit.HabitDataInitializer
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository
+import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 import spock.lang.Subject
 
 class GetMateUseCaseSpec extends IntegrationTestSpecification {
@@ -14,8 +19,16 @@ class GetMateUseCaseSpec extends IntegrationTestSpecification {
     @Autowired
     private HabitDataInitializer habitDataInitializer
 
+    @MockBean
+    private MemberRepository memberRepository
+
     def setup() {
         habitDataInitializer.initialize()
+        Mockito.when(
+                memberRepository.findByIdAndStatus(Mockito.any(Long.class), Mockito.any(MemberStatus.class))
+        ).thenReturn(
+                Optional.of(MemberEntity.builder().build())
+        )
     }
 
     def "사용자는 짝꿍 상세정보를 조회할 수 있다"() {

--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/member/SaveClientUseCaseSpec.groovy
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/member/SaveClientUseCaseSpec.groovy
@@ -1,10 +1,16 @@
 package com.depromeet.threedays.front.domain.usecase.member
 
+import com.depromeet.threedays.data.entity.member.MemberEntity
+import com.depromeet.threedays.data.enums.MemberStatus
 import com.depromeet.threedays.front.IntegrationTestSpecification
 import com.depromeet.threedays.front.domain.usecase.client.SaveClientUseCase
 import com.depromeet.threedays.front.persistence.repository.client.ClientRepository
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository
+import org.mockito.Mockito
+
 import com.depromeet.threedays.front.web.request.client.ClientRequest
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 import spock.lang.Subject
 
 //TODO: TestCode Refactor by jh
@@ -16,8 +22,16 @@ class SaveClientUseCaseSpec extends IntegrationTestSpecification {
     @Autowired
     private ClientRepository repository
 
+    @MockBean
+    private MemberRepository memberRepository
+
     def setup() {
         repository.deleteAll()
+        Mockito.when(
+                memberRepository.findByIdAndStatus(Mockito.any(Long.class), Mockito.any(MemberStatus.class))
+        ).thenReturn(
+                Optional.of(MemberEntity.builder().build())
+        )
     }
 
     def "사용자는 기기의 identificationKey와 fcmToken을 등록할 수 있다"() {

--- a/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/member/SaveMemberNameUseCaseSpec.groovy
+++ b/app/src/integration-test/groovy/com/depromeet/threedays/front/domain/usecase/member/SaveMemberNameUseCaseSpec.groovy
@@ -6,6 +6,7 @@ import com.depromeet.threedays.front.data.member.MemberInitializer
 import com.depromeet.threedays.front.persistence.repository.member.MemberRepository
 import com.depromeet.threedays.front.web.request.member.MemberNameUpdateRequest
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 
 class SaveMemberNameUseCaseSpec extends IntegrationTestSpecification {
 

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/SearchRecordUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/SearchRecordUseCase.java
@@ -7,6 +7,7 @@ import com.depromeet.threedays.front.config.security.AuditorHolder;
 import com.depromeet.threedays.front.domain.converter.habit.HabitConverter;
 import com.depromeet.threedays.front.domain.model.DatePeriod;
 import com.depromeet.threedays.front.domain.model.habit.Habit;
+import com.depromeet.threedays.front.exception.MemberNotFoundException;
 import com.depromeet.threedays.front.persistence.repository.RewardHistoryRepository;
 import com.depromeet.threedays.front.persistence.repository.habit.HabitAchievementRepository;
 import com.depromeet.threedays.front.persistence.repository.habit.HabitRepository;
@@ -40,6 +41,10 @@ public class SearchRecordUseCase {
 	private final RewardHistoryRepository rewardHistoryRepository;
 
 	public RecordResponse execute(final SearchRecordRequest request) {
+		Long memberId = AuditorHolder.get();
+		memberRepository
+				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
 
 		MemberEntity memberEntity =
 				memberRepository

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/client/DeleteClientUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/client/DeleteClientUseCase.java
@@ -1,6 +1,10 @@
 package com.depromeet.threedays.front.domain.usecase.client;
 
+import com.depromeet.threedays.data.enums.MemberStatus;
+import com.depromeet.threedays.front.config.security.AuditorHolder;
+import com.depromeet.threedays.front.exception.MemberNotFoundException;
 import com.depromeet.threedays.front.persistence.repository.client.ClientRepository;
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository;
 import com.depromeet.threedays.front.web.request.client.DeleteClientRequest;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -12,9 +16,15 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class DeleteClientUseCase {
 
+	private final MemberRepository memberRepository;
 	private final ClientRepository clientRepository;
 
 	public void execute(@Valid DeleteClientRequest query) {
+		Long memberId = AuditorHolder.get();
+		memberRepository
+				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
+
 		clientRepository.deleteByIdentificationKey(query.getIdentificationKey());
 	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/client/SaveClientUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/client/SaveClientUseCase.java
@@ -1,9 +1,12 @@
 package com.depromeet.threedays.front.domain.usecase.client;
 
+import com.depromeet.threedays.data.enums.MemberStatus;
 import com.depromeet.threedays.front.config.security.AuditorHolder;
 import com.depromeet.threedays.front.domain.converter.client.ClientConverter;
 import com.depromeet.threedays.front.domain.model.client.Client;
+import com.depromeet.threedays.front.exception.MemberNotFoundException;
 import com.depromeet.threedays.front.persistence.repository.client.ClientRepository;
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository;
 import com.depromeet.threedays.front.web.request.client.ClientRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,10 +17,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class SaveClientUseCase {
 
+	private final MemberRepository memberRepository;
 	private final ClientRepository repository;
 
 	public Client execute(final ClientRequest request) {
 		Long memberId = AuditorHolder.get();
+		memberRepository
+				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
 		Client source =
 				repository
 						.findByMemberIdAndIdentificationKey(memberId, request.getIdentificationKey())

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/DeleteHabitAchievementUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/DeleteHabitAchievementUseCase.java
@@ -2,15 +2,19 @@ package com.depromeet.threedays.front.domain.usecase.habit;
 
 import com.depromeet.threedays.data.entity.habit.HabitAchievementEntity;
 import com.depromeet.threedays.data.entity.habit.HabitEntity;
+import com.depromeet.threedays.data.enums.MemberStatus;
+import com.depromeet.threedays.front.config.security.AuditorHolder;
 import com.depromeet.threedays.front.domain.converter.habit.HabitAchievementConverter;
 import com.depromeet.threedays.front.domain.converter.habit.HabitConverter;
 import com.depromeet.threedays.front.domain.model.habit.Habit;
 import com.depromeet.threedays.front.domain.model.habit.HabitAchievement;
 import com.depromeet.threedays.front.domain.validation.HabitAchievementValidator;
+import com.depromeet.threedays.front.exception.MemberNotFoundException;
 import com.depromeet.threedays.front.exception.ResourceNotFoundException;
 import com.depromeet.threedays.front.persistence.repository.RewardHistoryRepository;
 import com.depromeet.threedays.front.persistence.repository.habit.HabitAchievementRepository;
 import com.depromeet.threedays.front.persistence.repository.habit.HabitRepository;
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DeleteHabitAchievementUseCase {
 
+	private final MemberRepository memberRepository;
 	private final HabitRepository habitRepository;
 	private final HabitAchievementRepository repository;
 	private final RewardHistoryRepository rewardHistoryRepository;
@@ -27,6 +32,11 @@ public class DeleteHabitAchievementUseCase {
 	private final HabitAchievementValidator validator;
 
 	public Habit execute(final Long habitId, final Long habitAchievementId) {
+		Long memberId = AuditorHolder.get();
+		memberRepository
+				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
+
 		HabitEntity habitEntity =
 				habitRepository.findById(habitId).orElseThrow(ResourceNotFoundException::new);
 		HabitAchievementEntity entity = repository.findById(habitAchievementId).orElse(null);

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/DeleteHabitUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/DeleteHabitUseCase.java
@@ -2,13 +2,17 @@ package com.depromeet.threedays.front.domain.usecase.habit;
 
 import com.depromeet.threedays.data.enums.HabitStatus;
 import com.depromeet.threedays.data.enums.MateStatus;
+import com.depromeet.threedays.data.enums.MemberStatus;
+import com.depromeet.threedays.front.config.security.AuditorHolder;
 import com.depromeet.threedays.front.domain.converter.habit.HabitConverter;
 import com.depromeet.threedays.front.domain.converter.mate.MateConverter;
 import com.depromeet.threedays.front.domain.model.habit.Habit;
 import com.depromeet.threedays.front.domain.model.mate.Mate;
+import com.depromeet.threedays.front.exception.MemberNotFoundException;
 import com.depromeet.threedays.front.persistence.repository.habit.HabitAchievementRepository;
 import com.depromeet.threedays.front.persistence.repository.habit.HabitRepository;
 import com.depromeet.threedays.front.persistence.repository.mate.MateRepository;
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository;
 import com.depromeet.threedays.front.persistence.repository.notification.HabitNotificationRepository;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +23,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class DeleteHabitUseCase {
 
+	private final MemberRepository memberRepository;
 	private final HabitRepository repository;
 	private final HabitAchievementRepository habitAchievementRepository;
 	private final MateRepository mateRepository;
@@ -26,6 +31,11 @@ public class DeleteHabitUseCase {
 	private final HabitNotificationRepository habitNotificationRepository;
 
 	public void execute(Long habitId) {
+		Long memberId = AuditorHolder.get();
+		memberRepository
+				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
+
 		Habit source =
 				repository.findByIdAndDeletedFalse(habitId).map(HabitConverter::from).orElse(null);
 

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/GetHabitUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/GetHabitUseCase.java
@@ -2,6 +2,8 @@ package com.depromeet.threedays.front.domain.usecase.habit;
 
 import com.depromeet.threedays.data.entity.habit.HabitEntity;
 import com.depromeet.threedays.data.entity.mate.MateEntity;
+import com.depromeet.threedays.data.enums.MemberStatus;
+import com.depromeet.threedays.front.config.security.AuditorHolder;
 import com.depromeet.threedays.front.domain.converter.habit.HabitAchievementConverter;
 import com.depromeet.threedays.front.domain.converter.habit.HabitConverter;
 import com.depromeet.threedays.front.domain.converter.mate.MateConverter;
@@ -9,11 +11,13 @@ import com.depromeet.threedays.front.domain.converter.notification.HabitNotifica
 import com.depromeet.threedays.front.domain.model.habit.Habit;
 import com.depromeet.threedays.front.domain.model.habit.HabitAchievement;
 import com.depromeet.threedays.front.domain.model.notification.Notification;
+import com.depromeet.threedays.front.exception.MemberNotFoundException;
 import com.depromeet.threedays.front.exception.ResourceNotFoundException;
 import com.depromeet.threedays.front.persistence.repository.RewardHistoryRepository;
 import com.depromeet.threedays.front.persistence.repository.habit.HabitAchievementRepository;
 import com.depromeet.threedays.front.persistence.repository.habit.HabitRepository;
 import com.depromeet.threedays.front.persistence.repository.mate.MateRepository;
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository;
 import com.depromeet.threedays.front.persistence.repository.notification.HabitNotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class GetHabitUseCase {
 
+	private final MemberRepository memberRepository;
 	private final HabitRepository repository;
 	private final HabitAchievementRepository habitAchievementRepository;
 	private final MateRepository mateRepository;
@@ -31,6 +36,11 @@ public class GetHabitUseCase {
 	private final RewardHistoryRepository rewardHistoryRepository;
 
 	public Habit execute(final Long id) {
+		Long memberId = AuditorHolder.get();
+		memberRepository
+				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
+
 		HabitEntity source = repository.findById(id).orElseThrow(ResourceNotFoundException::new);
 
 		MateEntity mateEntity =

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitAchievementUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitAchievementUseCase.java
@@ -3,6 +3,8 @@ package com.depromeet.threedays.front.domain.usecase.habit;
 import com.depromeet.threedays.data.entity.habit.HabitAchievementEntity;
 import com.depromeet.threedays.data.entity.habit.HabitEntity;
 import com.depromeet.threedays.data.enums.LevelUpSection;
+import com.depromeet.threedays.data.enums.MemberStatus;
+import com.depromeet.threedays.front.config.security.AuditorHolder;
 import com.depromeet.threedays.front.domain.converter.RewardHistoryConverter;
 import com.depromeet.threedays.front.domain.converter.habit.HabitAchievementConverter;
 import com.depromeet.threedays.front.domain.converter.habit.HabitConverter;
@@ -11,11 +13,13 @@ import com.depromeet.threedays.front.domain.model.habit.Habit;
 import com.depromeet.threedays.front.domain.model.habit.HabitAchievement;
 import com.depromeet.threedays.front.domain.model.mate.Mate;
 import com.depromeet.threedays.front.domain.validation.HabitAchievementValidator;
+import com.depromeet.threedays.front.exception.MemberNotFoundException;
 import com.depromeet.threedays.front.exception.ResourceNotFoundException;
 import com.depromeet.threedays.front.persistence.repository.RewardHistoryRepository;
 import com.depromeet.threedays.front.persistence.repository.habit.HabitAchievementRepository;
 import com.depromeet.threedays.front.persistence.repository.habit.HabitRepository;
 import com.depromeet.threedays.front.persistence.repository.mate.MateRepository;
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository;
 import com.depromeet.threedays.front.support.DateCalculator;
 import com.depromeet.threedays.front.web.request.habit.SaveHabitAchievementRequest;
 import java.time.LocalDate;
@@ -30,6 +34,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class SaveHabitAchievementUseCase {
 
 	private static final int PROVIDE_REWARD_COUNT = 3;
+
+	private final MemberRepository memberRepository;
 	private final HabitAchievementRepository repository;
 	private final HabitRepository habitRepository;
 
@@ -38,6 +44,10 @@ public class SaveHabitAchievementUseCase {
 	private final HabitAchievementValidator validator;
 
 	public Habit execute(Long habitId, final SaveHabitAchievementRequest request) {
+		Long memberId = AuditorHolder.get();
+		memberRepository
+				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
 
 		validator.validateCreateConstraints(HabitAchievementConverter.from(request));
 

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SaveHabitUseCase.java
@@ -1,12 +1,16 @@
 package com.depromeet.threedays.front.domain.usecase.habit;
 
 import com.depromeet.threedays.data.entity.habit.HabitEntity;
+import com.depromeet.threedays.data.enums.MemberStatus;
+import com.depromeet.threedays.front.config.security.AuditorHolder;
 import com.depromeet.threedays.front.domain.converter.habit.HabitConverter;
 import com.depromeet.threedays.front.domain.converter.notification.HabitNotificationConverter;
 import com.depromeet.threedays.front.domain.model.habit.Habit;
 import com.depromeet.threedays.front.domain.model.notification.Notification;
 import com.depromeet.threedays.front.domain.validation.HabitValidator;
+import com.depromeet.threedays.front.exception.MemberNotFoundException;
 import com.depromeet.threedays.front.persistence.repository.habit.HabitRepository;
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository;
 import com.depromeet.threedays.front.persistence.repository.notification.HabitNotificationRepository;
 import com.depromeet.threedays.front.web.request.habit.SaveHabitRequest;
 import java.time.DayOfWeek;
@@ -20,12 +24,18 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SaveHabitUseCase {
 
+	private final MemberRepository memberRepository;
 	private final HabitRepository repository;
 	private final HabitNotificationRepository habitNotificationRepository;
 
 	private final HabitValidator validator;
 
 	public Habit execute(final SaveHabitRequest request) {
+		Long memberId = AuditorHolder.get();
+		memberRepository
+				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
+
 		Habit data = HabitConverter.from(request);
 		validator.validateCreateConstraints(data);
 

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SearchHabitAchievementUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SearchHabitAchievementUseCase.java
@@ -1,13 +1,17 @@
 package com.depromeet.threedays.front.domain.usecase.habit;
 
+import com.depromeet.threedays.data.enums.MemberStatus;
+import com.depromeet.threedays.front.config.security.AuditorHolder;
 import com.depromeet.threedays.front.domain.converter.habit.HabitAchievementConverter;
 import com.depromeet.threedays.front.domain.converter.habit.HabitConverter;
 import com.depromeet.threedays.front.domain.model.DatePeriod;
 import com.depromeet.threedays.front.domain.model.habit.Habit;
 import com.depromeet.threedays.front.domain.model.habit.HabitAchievement;
+import com.depromeet.threedays.front.exception.MemberNotFoundException;
 import com.depromeet.threedays.front.exception.ResourceNotFoundException;
 import com.depromeet.threedays.front.persistence.repository.habit.HabitAchievementRepository;
 import com.depromeet.threedays.front.persistence.repository.habit.HabitRepository;
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository;
 import com.depromeet.threedays.front.web.request.habit.SearchHabitAchievementRequest;
 import java.time.LocalDate;
 import java.util.List;
@@ -22,12 +26,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class SearchHabitAchievementUseCase {
 
+	private final MemberRepository memberRepository;
 	private final HabitAchievementRepository repository;
-
 	private final HabitRepository habitRepository;
 
 	public List<HabitAchievement> execute(
 			final Long habitId, final SearchHabitAchievementRequest request) {
+		Long memberId = AuditorHolder.get();
+		memberRepository
+				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
 
 		Habit habit =
 				habitRepository

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SearchHabitUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/SearchHabitUseCase.java
@@ -4,15 +4,18 @@ import com.depromeet.threedays.data.entity.habit.HabitAchievementEntity;
 import com.depromeet.threedays.data.entity.habit.HabitEntity;
 import com.depromeet.threedays.data.enums.HabitStatus;
 import com.depromeet.threedays.data.enums.MateStatus;
+import com.depromeet.threedays.data.enums.MemberStatus;
 import com.depromeet.threedays.front.config.security.AuditorHolder;
 import com.depromeet.threedays.front.domain.converter.habit.HabitConverter;
 import com.depromeet.threedays.front.domain.model.habit.HabitAchievement;
 import com.depromeet.threedays.front.domain.model.habit.HabitOverview;
 import com.depromeet.threedays.front.domain.model.mate.Mate;
+import com.depromeet.threedays.front.exception.MemberNotFoundException;
 import com.depromeet.threedays.front.persistence.repository.RewardHistoryRepository;
 import com.depromeet.threedays.front.persistence.repository.habit.HabitAchievementRepository;
 import com.depromeet.threedays.front.persistence.repository.habit.HabitRepository;
 import com.depromeet.threedays.front.persistence.repository.mate.MateRepository;
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository;
 import com.depromeet.threedays.front.web.request.habit.SearchHabitRequest;
 import com.depromeet.threedays.front.web.response.assembler.MateAssembler;
 import java.time.LocalDate;
@@ -27,15 +30,19 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class SearchHabitUseCase {
 
+	private final MemberRepository memberRepository;
 	private final HabitRepository repository;
-
 	private final HabitAchievementRepository habitAchievementRepository;
-
 	private final RewardHistoryRepository rewardHistoryRepository;
 	private final MateRepository mateRepository;
 	private final MateAssembler mateAssembler;
 
 	public List<HabitOverview> execute(final SearchHabitRequest request) {
+		Long memberId = AuditorHolder.get();
+		memberRepository
+				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
+
 		List<HabitEntity> habitEntities = new ArrayList<>();
 		List<HabitOverview> habitOverviews = new ArrayList<>();
 

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/UpdateHabitUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/habit/UpdateHabitUseCase.java
@@ -1,5 +1,7 @@
 package com.depromeet.threedays.front.domain.usecase.habit;
 
+import com.depromeet.threedays.data.enums.MemberStatus;
+import com.depromeet.threedays.front.config.security.AuditorHolder;
 import com.depromeet.threedays.front.domain.converter.habit.HabitAchievementConverter;
 import com.depromeet.threedays.front.domain.converter.habit.HabitConverter;
 import com.depromeet.threedays.front.domain.converter.notification.HabitNotificationConverter;
@@ -7,9 +9,11 @@ import com.depromeet.threedays.front.domain.model.habit.Habit;
 import com.depromeet.threedays.front.domain.model.habit.HabitAchievement;
 import com.depromeet.threedays.front.domain.model.notification.Notification;
 import com.depromeet.threedays.front.domain.validation.HabitValidator;
+import com.depromeet.threedays.front.exception.MemberNotFoundException;
 import com.depromeet.threedays.front.exception.ResourceNotFoundException;
 import com.depromeet.threedays.front.persistence.repository.habit.HabitAchievementRepository;
 import com.depromeet.threedays.front.persistence.repository.habit.HabitRepository;
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository;
 import com.depromeet.threedays.front.persistence.repository.notification.HabitNotificationRepository;
 import com.depromeet.threedays.front.web.request.habit.UpdateHabitRequest;
 import java.time.DayOfWeek;
@@ -24,14 +28,18 @@ import org.springframework.util.Assert;
 @RequiredArgsConstructor
 public class UpdateHabitUseCase {
 
+	private final MemberRepository memberRepository;
 	private final HabitRepository repository;
-
 	private final HabitAchievementRepository habitAchievementRepository;
 	private final HabitNotificationRepository habitNotificationRepository;
-
 	private final HabitValidator habitValidator;
 
 	public Habit execute(final Long habitId, final UpdateHabitRequest request) {
+		Long memberId = AuditorHolder.get();
+		memberRepository
+				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
+
 		habitValidator.validateUpdateConstraints(request);
 		Habit habit =
 				repository

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/mate/DeleteMateUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/mate/DeleteMateUseCase.java
@@ -1,8 +1,12 @@
 package com.depromeet.threedays.front.domain.usecase.mate;
 
 import com.depromeet.threedays.data.entity.mate.MateEntity;
+import com.depromeet.threedays.data.enums.MemberStatus;
+import com.depromeet.threedays.front.config.security.AuditorHolder;
 import com.depromeet.threedays.front.domain.validation.MateValidator;
+import com.depromeet.threedays.front.exception.MemberNotFoundException;
 import com.depromeet.threedays.front.persistence.repository.mate.MateRepository;
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,11 +16,16 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DeleteMateUseCase {
 
+	private final MemberRepository memberRepository;
 	private final MateRepository repository;
-
 	private final MateValidator validator;
 
 	public void execute(final Long habitId, final Long id) {
+		Long memberId = AuditorHolder.get();
+		memberRepository
+				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
+
 		validator.validateDeleteConstraints(habitId);
 
 		MateEntity entity = repository.findById(id).orElse(null);

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/mate/GetMateCheckUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/mate/GetMateCheckUseCase.java
@@ -1,9 +1,12 @@
 package com.depromeet.threedays.front.domain.usecase.mate;
 
 import com.depromeet.threedays.data.enums.MateStatus;
+import com.depromeet.threedays.data.enums.MemberStatus;
 import com.depromeet.threedays.front.config.security.AuditorHolder;
 import com.depromeet.threedays.front.domain.converter.mate.MateConverter;
+import com.depromeet.threedays.front.exception.MemberNotFoundException;
 import com.depromeet.threedays.front.persistence.repository.mate.MateRepository;
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository;
 import com.depromeet.threedays.front.web.response.MateResponse;
 import com.depromeet.threedays.front.web.response.assembler.MateAssembler;
 import java.util.List;
@@ -17,10 +20,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class GetMateCheckUseCase {
 
+	private final MemberRepository memberRepository;
 	private final MateRepository mateRepository;
 	private final MateAssembler mateAssembler;
 
 	public List<MateResponse> execute() {
+		Long memberId = AuditorHolder.get();
+		memberRepository
+				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
+
 		return mateRepository
 				.findByMemberIdAndDeletedFalseAndStatus(AuditorHolder.get(), MateStatus.ACTIVE)
 				.stream()

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/mate/GetMateUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/mate/GetMateUseCase.java
@@ -1,10 +1,14 @@
 package com.depromeet.threedays.front.domain.usecase.mate;
 
+import com.depromeet.threedays.data.enums.MemberStatus;
+import com.depromeet.threedays.front.config.security.AuditorHolder;
 import com.depromeet.threedays.front.domain.converter.mate.MateConverter;
 import com.depromeet.threedays.front.domain.model.mate.Mate;
+import com.depromeet.threedays.front.exception.MemberNotFoundException;
 import com.depromeet.threedays.front.exception.ResourceNotFoundException;
 import com.depromeet.threedays.front.persistence.repository.habit.HabitRepository;
 import com.depromeet.threedays.front.persistence.repository.mate.MateRepository;
+import com.depromeet.threedays.front.persistence.repository.member.MemberRepository;
 import com.depromeet.threedays.front.web.response.MateResponse;
 import com.depromeet.threedays.front.web.response.assembler.MateAssembler;
 import lombok.RequiredArgsConstructor;
@@ -16,12 +20,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class GetMateUseCase {
 
+	private final MemberRepository memberRepository;
 	private final HabitRepository habitRepository;
 	private final MateRepository repository;
-
 	private final MateAssembler mateAssembler;
 
 	public MateResponse execute(final Long habitId, final Long id) {
+		Long memberId = AuditorHolder.get();
+		memberRepository
+				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
+
 		if (Boolean.FALSE.equals(habitRepository.existsByIdAndDeletedFalse(habitId))) {
 			throw new ResourceNotFoundException();
 		}

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/member/DeleteMemberUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/member/DeleteMemberUseCase.java
@@ -16,7 +16,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -35,11 +34,6 @@ public class DeleteMemberUseCase {
 	public Member execute() {
 		Long memberId = AuditorHolder.get();
 		Member member = quit(memberId);
-		// XXX: 앱 심사동안 테스트계정 탈퇴시 에러 안나게 임시 조치. 심사마치고 카카오 개발/운영환경 분리하면 삭제해야함
-		if (Objects.equals(9L, memberId)) {
-			log.warn("Ignored to unlink social account. member: {}", member);
-			return member;
-		}
 		unlinkSocialAccount(memberId);
 		return member;
 	}

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/member/SaveConsentUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/member/SaveConsentUseCase.java
@@ -5,7 +5,7 @@ import com.depromeet.threedays.data.enums.MemberStatus;
 import com.depromeet.threedays.front.config.security.AuditorHolder;
 import com.depromeet.threedays.front.domain.converter.member.MemberConverter;
 import com.depromeet.threedays.front.domain.model.member.Member;
-import com.depromeet.threedays.front.exception.ResourceNotFoundException;
+import com.depromeet.threedays.front.exception.MemberNotFoundException;
 import com.depromeet.threedays.front.persistence.repository.member.MemberRepository;
 import com.depromeet.threedays.front.web.request.member.MemberNotificationConsentUpdateRequest;
 import lombok.RequiredArgsConstructor;
@@ -21,14 +21,17 @@ public class SaveConsentUseCase {
 
 	public Member execute(final MemberNotificationConsentUpdateRequest request) {
 		Long memberId = AuditorHolder.get();
+		memberRepository
+				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
 		return MemberConverter.from(updateNotificationConsent(memberId, request));
 	}
 
-	public MemberEntity updateNotificationConsent(
+	private MemberEntity updateNotificationConsent(
 			final Long memberId, final MemberNotificationConsentUpdateRequest request) {
 		return memberRepository
 				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
 				.map(it -> it.updateNotificationConsent(request.isNotificationConsent()))
-				.orElseThrow(() -> new ResourceNotFoundException("member.not.found"));
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
 	}
 }

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/member/SaveMemberUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/member/SaveMemberUseCase.java
@@ -20,6 +20,7 @@ public class SaveMemberUseCase {
 	private final TokenGenerator tokenGenerator;
 
 	public SaveMemberUseCaseResponse execute(SaveMemberCommand command) {
+
 		MemberEntity memberEntity = memberRepository.save(MemberConverter.to(command));
 		Token token = tokenGenerator.generateToken(memberEntity.getId());
 		return MemberConverter.from(memberEntity, true, token);

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/member/SaveNameUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/member/SaveNameUseCase.java
@@ -5,6 +5,7 @@ import com.depromeet.threedays.data.enums.MemberStatus;
 import com.depromeet.threedays.front.config.security.AuditorHolder;
 import com.depromeet.threedays.front.domain.converter.member.MemberConverter;
 import com.depromeet.threedays.front.domain.model.member.Member;
+import com.depromeet.threedays.front.exception.MemberNotFoundException;
 import com.depromeet.threedays.front.exception.ResourceNotFoundException;
 import com.depromeet.threedays.front.persistence.repository.member.MemberRepository;
 import com.depromeet.threedays.front.web.request.member.MemberNameUpdateRequest;
@@ -21,10 +22,13 @@ public class SaveNameUseCase {
 
 	public Member execute(final MemberNameUpdateRequest request) {
 		Long memberId = AuditorHolder.get();
+		memberRepository
+				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
 		return MemberConverter.from(this.updateName(memberId, request));
 	}
 
-	public MemberEntity updateName(final Long memberId, final MemberNameUpdateRequest request) {
+	private MemberEntity updateName(final Long memberId, final MemberNameUpdateRequest request) {
 		return memberRepository
 				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
 				.map(it -> it.updateName(request.getName()))

--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/member/SaveResourceUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/member/SaveResourceUseCase.java
@@ -5,6 +5,7 @@ import com.depromeet.threedays.data.enums.MemberStatus;
 import com.depromeet.threedays.front.config.security.AuditorHolder;
 import com.depromeet.threedays.front.domain.converter.member.MemberConverter;
 import com.depromeet.threedays.front.domain.model.member.Member;
+import com.depromeet.threedays.front.exception.MemberNotFoundException;
 import com.depromeet.threedays.front.exception.ResourceNotFoundException;
 import com.depromeet.threedays.front.persistence.repository.member.MemberRepository;
 import com.depromeet.threedays.front.support.converter.MemberInfoJsonConverter;
@@ -26,6 +27,9 @@ public class SaveResourceUseCase {
 
 	public Member execute(final MemberResourceUpdateRequest request) {
 		Long memberId = AuditorHolder.get();
+		memberRepository
+				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
 		return MemberConverter.from(this.updateResource(memberId, request));
 	}
 

--- a/app/src/main/java/com/depromeet/threedays/front/exception/MemberNotFoundException.java
+++ b/app/src/main/java/com/depromeet/threedays/front/exception/MemberNotFoundException.java
@@ -1,0 +1,15 @@
+package com.depromeet.threedays.front.exception;
+
+/** accessToken 의 memberId 로 회원 조회 실패시 발생하는 예외 */
+public class MemberNotFoundException extends RuntimeException {
+	private final Long memberId;
+
+	public MemberNotFoundException(Long memberId) {
+		this.memberId = memberId;
+	}
+
+	@Override
+	public String getMessage() {
+		return "존재하지 않는 회원입니다. memberId: " + memberId;
+	}
+}

--- a/app/src/main/java/com/depromeet/threedays/front/web/controller/ApiControllerExceptionHandler.java
+++ b/app/src/main/java/com/depromeet/threedays/front/web/controller/ApiControllerExceptionHandler.java
@@ -1,9 +1,6 @@
 package com.depromeet.threedays.front.web.controller;
 
-import com.depromeet.threedays.front.exception.JsonParsingException;
-import com.depromeet.threedays.front.exception.PolicyViolationException;
-import com.depromeet.threedays.front.exception.RefreshTokenInvalidException;
-import com.depromeet.threedays.front.exception.ResourceNotFoundException;
+import com.depromeet.threedays.front.exception.*;
 import com.depromeet.threedays.front.support.ApiResponse;
 import com.depromeet.threedays.front.support.ApiResponseGenerator;
 import javax.servlet.http.HttpServletRequest;
@@ -98,7 +95,7 @@ public class ApiControllerExceptionHandler {
 		return ApiResponseGenerator.fail(FAIL_CODE, FORBIDDEN_MESSAGE, HttpStatus.FORBIDDEN);
 	}
 
-	@ExceptionHandler(AuthenticationException.class)
+	@ExceptionHandler({AuthenticationException.class, MemberNotFoundException.class})
 	public ApiResponse<ApiResponse.FailureBody> handle(
 			final AuthenticationException ex, final WebRequest request) {
 		this.writeLog(ex, request);


### PR DESCRIPTION
💁‍♂️ PR 내용
----

**[AS-IS]**
- 탈퇴한 회원으로 api 호출시 400 에러 발생하는데, 약속되지 않은 에러라서 이후 앱 동작이 이상함

**[TO-BE]**
- 회원 조회 실패시 401 예외 발생

