### PR TITLE
DEP-000 fix: 내정보 조회 실패시 404 발생하는 현상 해결

### DIFF
--- a/app/src/main/java/com/depromeet/threedays/front/domain/usecase/member/GetMemberUseCase.java
+++ b/app/src/main/java/com/depromeet/threedays/front/domain/usecase/member/GetMemberUseCase.java
@@ -8,7 +8,7 @@ import com.depromeet.threedays.front.domain.model.member.Member;
 import com.depromeet.threedays.front.domain.model.member.SaveMemberUseCaseResponse;
 import com.depromeet.threedays.front.domain.model.member.Token;
 import com.depromeet.threedays.front.domain.query.GetMemberQuery;
-import com.depromeet.threedays.front.exception.ResourceNotFoundException;
+import com.depromeet.threedays.front.exception.MemberNotFoundException;
 import com.depromeet.threedays.front.persistence.repository.member.MemberRepository;
 import com.depromeet.threedays.front.support.TokenGenerator;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +41,6 @@ public class GetMemberUseCase {
 		return memberRepository
 				.findByIdAndStatus(memberId, MemberStatus.REGULAR)
 				.map(MemberConverter::from)
-				.orElseThrow(ResourceNotFoundException::new);
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
 	}
 }


### PR DESCRIPTION
💁‍♂️ PR 내용
----

**[AS-IS]**
- 내 정보 조회시 회원 못찾으면 404

**[TO-BE]**
- 내 정보 조회시 회원 못찾으면 401
